### PR TITLE
Version 3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For example when pushing changes to version 3, the pull request should use the `
 
 - When adding new stuff, please remember to add new unit-tests for the functionality.
 
-#### Credits
+#### Credits & features
 
 This project is based on the original [Pixie project by usmanhalalit](https://github.com/usmanhalalit/pixie) but has some extra features like:
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This library is stable, maintained and are used by many sites, including:
 **Requirements:**
 - PHP 5.6 or higher is required.
 
+Versions prior to 3.x are available [here](https://github.com/skipperbent/pixie).
+
 #### Feedback and development
 
 If you are missing a feature, experience problems or have ideas or feedback that you want us to hear, please feel free to create an issue.
@@ -63,14 +65,10 @@ This project is based on the original [Pixie project by usmanhalalit](https://gi
 
 Most importantly this project is used on many live-sites and maintained.
 
-#### Versions prior to 3.x
-
-Older versions prior to 3.x are available [https://github.com/skipperbent/pixie](https://github.com/skipperbent/pixie).
-
 #### Note
 
-`AliasFacade` used for calling the database-connection as a fixed constant has been removed to increase performance.
-If this feature is required in your setup we encourage you to implement your own solution.
+`Facades` and `Container` support has been removed to increase performance. To implement your own adapters, please extends the
+`IConnectionAdapter` interface.
 
 ## Example
 ```php
@@ -79,7 +77,7 @@ require 'vendor/autoload.php';
 
 // Create a connection, once only.
 $config = array(
-            'driver'    => 'mysql', // Db driver
+            'driver'    => 'mysql', // Db driver or IConnectionAdapter class
             'host'      => 'localhost',
             'database'  => 'your-database',
             'username'  => 'root',
@@ -867,21 +865,23 @@ Pixie comes with powerful query events to supercharge your application. These ev
 
 #### Available Events
 
- - after-*
- - before-*
- - before-select
- - after-select
- - before-insert
- - after-insert
- - before-update
- - after-update
- - before-delete
- - after-delete
+| Event constant                        | Event value/name  | Description                                |
+| :------------------------------------ | :-------------    | :------------                              |
+| `EventHandler::EVENT_BEFORE_ALL`      | `before-*`        | Event-type that fires before each query.   |
+| `EventHandler::EVENT_AFTER_ALL`       | `after-*`         | Event-type that fires after each query.    |
+| `EventHandler::EVENT_BEFORE_SELECT`   | `before-select`   | Event-type that fires before select query. |
+| `EventHandler::EVENT_AFTER_SELECT`    | `after-select`    | Event-type that fires after insert query.  |
+| `EventHandler::EVENT_BEFORE_INSERT`   | `before-insert`   | Event-type that fires before insert query  |
+| `EventHandler::EVENT_AFTER_INSERT`    | `after-insert`    | Event-type that fires after insert query.  |
+| `EventHandler::EVENT_BEFORE_UPDATE`   | `before-update`   | Event-type that fires before update query. |
+| `EventHandler::EVENT_AFTER_UPDATE`    | `after-update`    | Event-type that fires after update query.  |
+| `EventHandler::EVENT_BEFORE_DELETE`   | `before-delete`   | Event-type that fires before delete query. |
+| `EventHandler::EVENT_AFTER_DELETE`    | `after-delete`    | Event-type that fires after delete query.  |
 
 #### Registering Events
 
 ```php
-$queryBuilder->registerEvent('before-select', 'users', function(QueryBuilderHandler $qb)
+$queryBuilder->registerEvent(EventHandler::EVENT_BEFORE_SELECT, 'users', function(QueryBuilderHandler $qb)
 {
     $qb->where('status', '!=', 'banned');
 });
@@ -897,7 +897,7 @@ If you want the event to be performed when **any table is being queried**, provi
 After inserting data into `my_table`, details will be inserted into another table
 
 ```php
-$queryBuilder->registerEvent('after-insert', 'my_table', function(QueryBuilderHandler $qb, $insertId)
+$queryBuilder->registerEvent(EventHandler::EVENT_AFTER_INSERT, 'my_table', function(QueryBuilderHandler $qb, $insertId)
 {
     $qb
         ->table('person_details')->insert(array(
@@ -911,7 +911,7 @@ $queryBuilder->registerEvent('after-insert', 'my_table', function(QueryBuilderHa
 Whenever data is inserted into `person_details` table, set the timestamp field `created_at`, so we don't have to specify it everywhere:
 
 ```php
-$queryBuilder->registerEvent('after-insert', 'person_details', function(QueryBuilderHandler $qb, $insertId)
+$queryBuilder->registerEvent(EventHandler::EVENT_AFTER_INSERT, 'person_details', function(QueryBuilderHandler $qb, $insertId)
 {
     $qb
         ->table('person_details')
@@ -925,7 +925,7 @@ $queryBuilder->registerEvent('after-insert', 'person_details', function(QueryBui
 After deleting from `my_table` delete the relations:
 
 ```php
-$queryBuilder->registerEvent('after-delete', 'my_table', function(QueryBuilderHandler $qb, $queryObject)
+$queryBuilder->registerEvent(EventHandler::EVENT_AFTER_DELETE, 'my_table', function(QueryBuilderHandler $qb, $queryObject)
 {
     $bindings = $queryObject->getBindings();
     $qb
@@ -949,7 +949,7 @@ Only on `after-*` events you get three parameters: **first** is the query builde
 #### Removing Events
 
 ```php
-$queryBuilder->removeEvent('event-name', 'table-name');
+$queryBuilder->removeEvent($event, $table = null);
 ```
 
 #### Some Use Cases

--- a/README.md
+++ b/README.md
@@ -266,19 +266,25 @@ $queryBuilder
     ->join('table2', 'table2.person_id', '=', 'foo1.id');
 ```
 
-You can change the alias anytime by using
+You can change the alias anytime by using:
 
 ```php
-$queryBuilder->alias($table, $alias);
+$queryBuilder->alias('foo1', 'table1');
+
+// Simplified way...
+
+$queryBuilder->table('table1')->alias('foo1');
 ```
 
 Output:
 
 ```sql
 SELECT *
-FROM `table1` AS foo1
+FROM `table1` AS `foo1`
 INNER JOIN `cb_table2` ON `cb_table2`.`person_id` = `cb_foo1`.`id`
 ```
+
+**Note:** If `$table` parameter is null - the querybuilder will use the table from latest call to `table($table)` method.
 
 ### Get Easily
 

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,7 @@
     }
   ],
   "require": {
-    "php": ">=5.6",
-    "usmanhalalit/viocon": "1.0.1"
+    "php": ">=5.6"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8",

--- a/src/Pecee/Pixie/Connection.php
+++ b/src/Pecee/Pixie/Connection.php
@@ -2,6 +2,7 @@
 
 namespace Pecee\Pixie;
 
+use PDO;
 use Pecee\Pixie\ConnectionAdapters\IConnectionAdapter;
 use Pecee\Pixie\QueryBuilder\QueryBuilderHandler;
 
@@ -10,147 +11,139 @@ use Pecee\Pixie\QueryBuilder\QueryBuilderHandler;
  *
  * @package Pecee\Pixie
  */
-class Connection
-{
+class Connection {
 
-    /**
-     * Name of DB adapter (i.e. Mysql, Pgsql, Sqlite)
-     * @var string
-     */
-    protected $adapter;
+	/**
+	 * Name of DB adapter (i.e. Mysql, Pgsql, Sqlite)
+	 * @var IConnectionAdapter
+	 */
+	protected $adapter;
 
-    /**
-     * @var array
-     */
-    protected $adapterConfig;
+	/**
+	 * @var array
+	 */
+	protected $adapterConfig;
 
-    /**
-     * @var \PDO
-     */
-    protected $pdoInstance;
+	/**
+	 * @var PDO
+	 */
+	protected $pdoInstance;
 
-    /**
-     * @var Connection
-     */
-    protected static $storedConnection;
+	/**
+	 * @var Connection
+	 */
+	protected static $storedConnection;
 
-    /**
-     * @var EventHandler
-     */
-    protected $eventHandler;
+	/**
+	 * @var EventHandler
+	 */
+	protected $eventHandler;
 
-    /**
-     * @param string|IConnectionAdapter $adapter
-     * @param array $adapterConfig
-     */
-    public function __construct($adapter, array $adapterConfig)
-    {
-        if(($adapter instanceof IConnectionAdapter) === false) {
-            $adapter = '\Pecee\Pixie\ConnectionAdapters\\' . ucfirst(strtolower($adapter));
-            $adapter = new $adapter();
-        }
+	/**
+	 * @param string|IConnectionAdapter $adapter
+	 * @param array $adapterConfig
+	 */
+	public function __construct($adapter, array $adapterConfig) {
+		if (($adapter instanceof IConnectionAdapter) === false) {
+			$adapter = '\Pecee\Pixie\ConnectionAdapters\\' . ucfirst(strtolower($adapter));
+			$adapter = new $adapter();
+		}
 
-        $this->setAdapter($adapter)->setAdapterConfig($adapterConfig)->connect();
+		$this->setAdapter($adapter)->setAdapterConfig($adapterConfig)->connect();
 
-        // Create event dependency
-        $this->eventHandler = new EventHandler();
-    }
+		// Create event dependency
+		$this->eventHandler = new EventHandler();
+	}
 
-    /**
-     * Returns an instance of Query Builder
-     * @throws Exception
-     * @return QueryBuilderHandler
-     */
-    public function getQueryBuilder()
-    {
-        return new QueryBuilderHandler($this);
-    }
+	/**
+	 * Returns an instance of Query Builder
+	 *
+	 * @return QueryBuilderHandler
+	 * @throws Exception
+	 */
+	public function getQueryBuilder() {
+		return new QueryBuilderHandler($this);
+	}
 
-    /**
-     * Create the connection adapter
-     */
-    protected function connect()
-    {
-        // Build a database connection if we don't have one connected
-        $pdo = $this->adapter->connect($this->adapterConfig);
-        $this->setPdoInstance($pdo);
+	/**
+	 * Create the connection adapter
+	 */
+	protected function connect() {
+		// Build a database connection if we don't have one connected
+		$pdo = $this->adapter->connect($this->adapterConfig);
+		$this->setPdoInstance($pdo);
 
-        // Preserve the first database connection with a static property
-        if (static::$storedConnection === null) {
-            static::$storedConnection = $this;
-        }
-    }
+		// Preserve the first database connection with a static property
+		if (static::$storedConnection === null) {
+			static::$storedConnection = $this;
+		}
+	}
 
-    /**
-     * @param \PDO $pdo
-     * @return static
-     */
-    public function setPdoInstance(\PDO $pdo)
-    {
-        $this->pdoInstance = $pdo;
+	/**
+	 * @param PDO $pdo
+	 *
+	 * @return static
+	 */
+	public function setPdoInstance(PDO $pdo) {
+		$this->pdoInstance = $pdo;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * @return \PDO
-     */
-    public function getPdoInstance()
-    {
-        return $this->pdoInstance;
-    }
+	/**
+	 * @return PDO
+	 */
+	public function getPdoInstance() {
+		return $this->pdoInstance;
+	}
 
-    /**
-     * @param IConnectionAdapter $adapter
-     * @return static
-     */
-    public function setAdapter(IConnectionAdapter $adapter)
-    {
-        $this->adapter = $adapter;
+	/**
+	 * @param IConnectionAdapter $adapter
+	 *
+	 * @return static
+	 */
+	public function setAdapter(IConnectionAdapter $adapter) {
+		$this->adapter = $adapter;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * @return IConnectionAdapter
-     */
-    public function getAdapter()
-    {
-        return $this->adapter;
-    }
+	/**
+	 * @return IConnectionAdapter
+	 */
+	public function getAdapter() {
+		return $this->adapter;
+	}
 
-    /**
-     * @param array $adapterConfig
-     * @return static
-     */
-    public function setAdapterConfig(array $adapterConfig)
-    {
-        $this->adapterConfig = $adapterConfig;
+	/**
+	 * @param array $adapterConfig
+	 *
+	 * @return static
+	 */
+	public function setAdapterConfig(array $adapterConfig) {
+		$this->adapterConfig = $adapterConfig;
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * @return array
-     */
-    public function getAdapterConfig()
-    {
-        return $this->adapterConfig;
-    }
+	/**
+	 * @return array
+	 */
+	public function getAdapterConfig() {
+		return $this->adapterConfig;
+	}
 
-    /**
-     * @return EventHandler
-     */
-    public function getEventHandler()
-    {
-        return $this->eventHandler;
-    }
+	/**
+	 * @return EventHandler
+	 */
+	public function getEventHandler() {
+		return $this->eventHandler;
+	}
 
-    /**
-     * @return Connection
-     */
-    public static function getStoredConnection()
-    {
-        return static::$storedConnection;
-    }
+	/**
+	 * @return Connection
+	 */
+	public static function getStoredConnection() {
+		return static::$storedConnection;
+	}
 }

--- a/src/Pecee/Pixie/Connection.php
+++ b/src/Pecee/Pixie/Connection.php
@@ -45,6 +45,7 @@ class Connection {
 	 */
 	public function __construct($adapter, array $adapterConfig) {
 		if (($adapter instanceof IConnectionAdapter) === false) {
+			/* @var $adapter IConnectionAdapter */
 			$adapter = '\Pecee\Pixie\ConnectionAdapters\\' . ucfirst(strtolower($adapter));
 			$adapter = new $adapter();
 		}

--- a/src/Pecee/Pixie/ConnectionAdapters/BaseAdapter.php
+++ b/src/Pecee/Pixie/ConnectionAdapters/BaseAdapter.php
@@ -10,11 +10,11 @@ namespace Pecee\Pixie\ConnectionAdapters;
 abstract class BaseAdapter implements IConnectionAdapter {
 
 	/**
-	 * @param $config
+	 * @param array $config
 	 *
 	 * @return \PDO
 	 */
-	public function connect($config) {
+	public function connect(array $config) {
 		if (isset($config['options']) === false) {
 			$config['options'] = [];
 		}

--- a/src/Pecee/Pixie/ConnectionAdapters/BaseAdapter.php
+++ b/src/Pecee/Pixie/ConnectionAdapters/BaseAdapter.php
@@ -2,27 +2,13 @@
 
 namespace Pecee\Pixie\ConnectionAdapters;
 
-use Viocon\Container;
-
 /**
  * Class BaseAdapter
  *
  * @package Pecee\Pixie\ConnectionAdapters
  */
-abstract class BaseAdapter
+abstract class BaseAdapter implements IConnectionAdapter
 {
-    /**
-     * @var \Viocon\Container
-     */
-    protected $container;
-
-    /**
-     * @param \Viocon\Container $container
-     */
-    public function __construct(Container $container)
-    {
-        $this->container = $container;
-    }
 
     /**
      * @param $config

--- a/src/Pecee/Pixie/ConnectionAdapters/BaseAdapter.php
+++ b/src/Pecee/Pixie/ConnectionAdapters/BaseAdapter.php
@@ -7,25 +7,25 @@ namespace Pecee\Pixie\ConnectionAdapters;
  *
  * @package Pecee\Pixie\ConnectionAdapters
  */
-abstract class BaseAdapter implements IConnectionAdapter
-{
+abstract class BaseAdapter implements IConnectionAdapter {
 
-    /**
-     * @param $config
-     * @return \PDO
-     */
-    public function connect($config)
-    {
-        if (isset($config['options']) === false) {
-            $config['options'] = [];
-        }
+	/**
+	 * @param $config
+	 *
+	 * @return \PDO
+	 */
+	public function connect($config) {
+		if (isset($config['options']) === false) {
+			$config['options'] = [];
+		}
 
-        return $this->doConnect($config);
-    }
+		return $this->doConnect($config);
+	}
 
-    /**
-     * @param array $config
-     * @return mixed
-     */
-    abstract protected function doConnect(array $config);
+	/**
+	 * @param array $config
+	 *
+	 * @return \PDO
+	 */
+	abstract protected function doConnect(array $config);
 }

--- a/src/Pecee/Pixie/ConnectionAdapters/Exception.php
+++ b/src/Pecee/Pixie/ConnectionAdapters/Exception.php
@@ -7,7 +7,6 @@ namespace Pecee\Pixie\ConnectionAdapters;
  *
  * @package Pecee\Pixie\ConnectionAdapters
  */
-class Exception extends \Pecee\Pixie\Exception
-{
+class Exception extends \Pecee\Pixie\Exception {
 
 }

--- a/src/Pecee/Pixie/ConnectionAdapters/IConnectionAdapter.php
+++ b/src/Pecee/Pixie/ConnectionAdapters/IConnectionAdapter.php
@@ -11,7 +11,7 @@ interface IConnectionAdapter {
 	 *
 	 * @return \PDO
 	 */
-	public function connect($config);
+	public function connect(array $config);
 
 	/**
 	 * Get query adapter class

--- a/src/Pecee/Pixie/ConnectionAdapters/IConnectionAdapter.php
+++ b/src/Pecee/Pixie/ConnectionAdapters/IConnectionAdapter.php
@@ -1,0 +1,10 @@
+<?php
+namespace Pecee\Pixie\ConnectionAdapters;
+
+interface IConnectionAdapter {
+
+    public function connect($config);
+
+    public function getQueryAdapterClass();
+
+}

--- a/src/Pecee/Pixie/ConnectionAdapters/IConnectionAdapter.php
+++ b/src/Pecee/Pixie/ConnectionAdapters/IConnectionAdapter.php
@@ -1,10 +1,22 @@
 <?php
+
 namespace Pecee\Pixie\ConnectionAdapters;
 
 interface IConnectionAdapter {
 
-    public function connect($config);
+	/**
+	 * Connect to database
+	 *
+	 * @param array $config
+	 *
+	 * @return \PDO
+	 */
+	public function connect($config);
 
-    public function getQueryAdapterClass();
+	/**
+	 * Get query adapter class
+	 * @return string
+	 */
+	public function getQueryAdapterClass();
 
 }

--- a/src/Pecee/Pixie/ConnectionAdapters/Mysql.php
+++ b/src/Pecee/Pixie/ConnectionAdapters/Mysql.php
@@ -38,15 +38,17 @@ class Mysql extends BaseAdapter
         /**
          * @var \PDO $connection
          */
-        $connection = $this->container->build(
-            \PDO::class,
-            [$connectionString, $config['username'], $config['password'], $config['options']]
-        );
+        $connection = new \PDO($connectionString, $config['username'], $config['password'], $config['options']);
 
-        if (isset($config['charset'])) {
+        if (isset($config['charset']) === true) {
             $connection->prepare("SET NAMES '{$config['charset']}'")->execute();
         }
 
         return $connection;
+    }
+
+    public function getQueryAdapterClass()
+    {
+        return \Pecee\Pixie\QueryBuilder\Adapters\Mysql::class;
     }
 }

--- a/src/Pecee/Pixie/ConnectionAdapters/Mysql.php
+++ b/src/Pecee/Pixie/ConnectionAdapters/Mysql.php
@@ -35,9 +35,6 @@ class Mysql extends BaseAdapter {
 			$connectionString .= ";unix_socket={$config['unix_socket']}";
 		}
 
-		/**
-		 * @var \PDO $connection
-		 */
 		$connection = new PDO($connectionString, $config['username'], $config['password'], $config['options']);
 
 		if (isset($config['charset']) === true) {

--- a/src/Pecee/Pixie/ConnectionAdapters/Mysql.php
+++ b/src/Pecee/Pixie/ConnectionAdapters/Mysql.php
@@ -2,53 +2,52 @@
 
 namespace Pecee\Pixie\ConnectionAdapters;
 
+use PDO;
+
 /**
  * Class Mysql
  *
  * @package Pecee\Pixie\ConnectionAdapters
  */
-class Mysql extends BaseAdapter
-{
-    /**
-     * @param array $config
-     *
-     * @return mixed
-     * @throws Exception
-     */
-    protected function doConnect(array $config)
-    {
-        if (extension_loaded('pdo_mysql') === false) {
-            throw new Exception(sprintf('%s library not loaded', 'pdo_mysql'));
-        }
+class Mysql extends BaseAdapter {
+	/**
+	 * @param array $config
+	 *
+	 * @return PDO
+	 * @throws Exception
+	 */
+	protected function doConnect(array $config) {
+		if (extension_loaded('pdo_mysql') === false) {
+			throw new Exception(sprintf('%s library not loaded', 'pdo_mysql'));
+		}
 
-        $connectionString = "mysql:dbname={$config['database']}";
+		$connectionString = "mysql:dbname={$config['database']}";
 
-        if (isset($config['host']) === true) {
-            $connectionString .= ";host={$config['host']}";
-        }
+		if (isset($config['host']) === true) {
+			$connectionString .= ";host={$config['host']}";
+		}
 
-        if (isset($config['port']) === true) {
-            $connectionString .= ";port={$config['port']}";
-        }
+		if (isset($config['port']) === true) {
+			$connectionString .= ";port={$config['port']}";
+		}
 
-        if (isset($config['unix_socket']) === true) {
-            $connectionString .= ";unix_socket={$config['unix_socket']}";
-        }
+		if (isset($config['unix_socket']) === true) {
+			$connectionString .= ";unix_socket={$config['unix_socket']}";
+		}
 
-        /**
-         * @var \PDO $connection
-         */
-        $connection = new \PDO($connectionString, $config['username'], $config['password'], $config['options']);
+		/**
+		 * @var \PDO $connection
+		 */
+		$connection = new PDO($connectionString, $config['username'], $config['password'], $config['options']);
 
-        if (isset($config['charset']) === true) {
-            $connection->prepare("SET NAMES '{$config['charset']}'")->execute();
-        }
+		if (isset($config['charset']) === true) {
+			$connection->prepare("SET NAMES '{$config['charset']}'")->execute();
+		}
 
-        return $connection;
-    }
+		return $connection;
+	}
 
-    public function getQueryAdapterClass()
-    {
-        return \Pecee\Pixie\QueryBuilder\Adapters\Mysql::class;
-    }
+	public function getQueryAdapterClass() {
+		return \Pecee\Pixie\QueryBuilder\Adapters\Mysql::class;
+	}
 }

--- a/src/Pecee/Pixie/ConnectionAdapters/Pgsql.php
+++ b/src/Pecee/Pixie/ConnectionAdapters/Pgsql.php
@@ -30,10 +30,7 @@ class Pgsql extends BaseAdapter
         /**
          * @var \PDO $connection
          */
-        $connection = $this->container->build(
-            \PDO::class,
-            [$connectionString, $config['username'], $config['password'], $config['options']]
-        );
+        $connection = new \PDO($connectionString, $config['username'], $config['password'], $config['options']);
 
         if (isset($config['charset']) === true) {
             $connection->prepare("SET NAMES '{$config['charset']}'")->execute();
@@ -45,4 +42,10 @@ class Pgsql extends BaseAdapter
 
         return $connection;
     }
+
+    public function getQueryAdapterClass()
+    {
+        return \Pecee\Pixie\QueryBuilder\Adapters\Pgsql::class;
+    }
+
 }

--- a/src/Pecee/Pixie/ConnectionAdapters/Pgsql.php
+++ b/src/Pecee/Pixie/ConnectionAdapters/Pgsql.php
@@ -2,50 +2,49 @@
 
 namespace Pecee\Pixie\ConnectionAdapters;
 
+use PDO;
+
 /**
  * Class Pgsql
  *
  * @package Pecee\Pixie\ConnectionAdapters
  */
-class Pgsql extends BaseAdapter
-{
-    /**
-     * @param array $config
-     *
-     * @return mixed
-     * @throws Exception
-     */
-    protected function doConnect(array $config)
-    {
-        if (extension_loaded('pdo_pgsql') === false) {
-            throw new Exception(sprintf('%s library not loaded', 'pdo_pgsql'));
-        }
+class Pgsql extends BaseAdapter {
+	/**
+	 * @param array $config
+	 *
+	 * @return PDO
+	 * @throws Exception
+	 */
+	protected function doConnect(array $config) {
+		if (extension_loaded('pdo_pgsql') === false) {
+			throw new Exception(sprintf('%s library not loaded', 'pdo_pgsql'));
+		}
 
-        $connectionString = "pgsql:host={$config['host']};dbname={$config['database']}";
+		$connectionString = "pgsql:host={$config['host']};dbname={$config['database']}";
 
-        if (isset($config['port']) === true) {
-            $connectionString .= ";port={$config['port']}";
-        }
+		if (isset($config['port']) === true) {
+			$connectionString .= ";port={$config['port']}";
+		}
 
-        /**
-         * @var \PDO $connection
-         */
-        $connection = new \PDO($connectionString, $config['username'], $config['password'], $config['options']);
+		/**
+		 * @var \PDO $connection
+		 */
+		$connection = new PDO($connectionString, $config['username'], $config['password'], $config['options']);
 
-        if (isset($config['charset']) === true) {
-            $connection->prepare("SET NAMES '{$config['charset']}'")->execute();
-        }
+		if (isset($config['charset']) === true) {
+			$connection->prepare("SET NAMES '{$config['charset']}'")->execute();
+		}
 
-        if (isset($config['schema']) === true) {
-            $connection->prepare("SET search_path TO '{$config['schema']}'")->execute();
-        }
+		if (isset($config['schema']) === true) {
+			$connection->prepare("SET search_path TO '{$config['schema']}'")->execute();
+		}
 
-        return $connection;
-    }
+		return $connection;
+	}
 
-    public function getQueryAdapterClass()
-    {
-        return \Pecee\Pixie\QueryBuilder\Adapters\Pgsql::class;
-    }
+	public function getQueryAdapterClass() {
+		return \Pecee\Pixie\QueryBuilder\Adapters\Pgsql::class;
+	}
 
 }

--- a/src/Pecee/Pixie/ConnectionAdapters/Sqlite.php
+++ b/src/Pecee/Pixie/ConnectionAdapters/Sqlite.php
@@ -2,33 +2,32 @@
 
 namespace Pecee\Pixie\ConnectionAdapters;
 
+use PDO;
+
 /**
  * Class Sqlite
  *
  * @package Pecee\Pixie\ConnectionAdapters
  */
-class Sqlite extends BaseAdapter
-{
-    /**
-     * @param array $config
-     *
-     * @return \PDO
-     * @throws Exception
-     */
-    public function doConnect(array $config)
-    {
-        if (extension_loaded('pdo_sqlite') === false) {
-            throw new Exception(sprintf('%s library not loaded', 'pdo_sqlite'));
-        }
+class Sqlite extends BaseAdapter {
+	/**
+	 * @param array $config
+	 *
+	 * @return PDO
+	 * @throws Exception
+	 */
+	public function doConnect(array $config) {
+		if (extension_loaded('pdo_sqlite') === false) {
+			throw new Exception(sprintf('%s library not loaded', 'pdo_sqlite'));
+		}
 
-        $connectionString = 'sqlite:' . $config['database'];
+		$connectionString = 'sqlite:' . $config['database'];
 
-        return new \PDO($connectionString, null, null, $config['options']);
-    }
+		return new PDO($connectionString, null, null, $config['options']);
+	}
 
-    public function getQueryAdapterClass()
-    {
-        return \Pecee\Pixie\QueryBuilder\Adapters\Sqlite::class;
-    }
+	public function getQueryAdapterClass() {
+		return \Pecee\Pixie\QueryBuilder\Adapters\Sqlite::class;
+	}
 
 }

--- a/src/Pecee/Pixie/ConnectionAdapters/Sqlite.php
+++ b/src/Pecee/Pixie/ConnectionAdapters/Sqlite.php
@@ -23,9 +23,12 @@ class Sqlite extends BaseAdapter
 
         $connectionString = 'sqlite:' . $config['database'];
 
-        return $this->container->build(
-            \PDO::class,
-            [$connectionString, null, null, $config['options']]
-        );
+        return new \PDO($connectionString, null, null, $config['options']);
     }
+
+    public function getQueryAdapterClass()
+    {
+        return \Pecee\Pixie\QueryBuilder\Adapters\Sqlite::class;
+    }
+
 }

--- a/src/Pecee/Pixie/Exception.php
+++ b/src/Pecee/Pixie/Exception.php
@@ -7,7 +7,6 @@ namespace Pecee\Pixie;
  *
  * @package Pecee\Pixie
  */
-class Exception extends \Exception
-{
+class Exception extends \Exception {
 
 }

--- a/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -25,11 +25,6 @@ abstract class BaseAdapter
     protected $connection;
 
     /**
-     * @var \Viocon\Container
-     */
-    protected $container;
-
-    /**
      * BaseAdapter constructor.
      *
      * @param \Pecee\Pixie\Connection $connection
@@ -37,7 +32,384 @@ abstract class BaseAdapter
     public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->container = $this->connection->getContainer();
+    }
+
+    /**
+     * Array concatenating method, like implode.
+     * But it does wrap sanitizer and trims last glue
+     *
+     * @param array $pieces
+     * @param string $glue
+     * @param bool $wrapSanitizer
+     * @return string
+     */
+    protected function arrayStr(array $pieces, $glue = ',', $wrapSanitizer = true)
+    {
+        $str = '';
+        foreach ($pieces as $key => $piece) {
+            if ($wrapSanitizer === true) {
+                $piece = $this->wrapSanitizer($piece);
+            }
+
+            if (\is_int($key) === false) {
+                $piece = ($wrapSanitizer ? $this->wrapSanitizer($key) : $key) . ' AS ' . $piece;
+            }
+
+            $str .= $piece . $glue;
+        }
+
+        return trim($str, $glue);
+    }
+
+    /**
+     * Build generic criteria string and bindings from statements, like "a = b and c = ?"
+     *
+     * @param array $statements
+     * @param bool $bindValues
+     * @throws Exception
+     * @return array
+     */
+    protected function buildCriteria(array $statements, $bindValues = true)
+    {
+        $criteria = '';
+        $bindings = [[]];
+
+        foreach ($statements as $statement) {
+
+            $key = $this->wrapSanitizer($statement['key']);
+            $value = $statement['value'];
+
+            if ($value === null && $key instanceof \Closure) {
+
+                /**
+                 * We have a closure, a nested criteria
+                 * Build a new NestedCriteria class, keep it by reference so any changes made in the closure should reflect here
+                 */
+
+                /* @var $nestedCriteria NestedCriteria */
+                $nestedCriteria = new NestedCriteria($this->connection);
+
+                // Call the closure with our new nestedCriteria object
+                $key($nestedCriteria);
+
+                // Get the criteria only query from the nestedCriteria object
+                $queryObject = $nestedCriteria->getQuery('criteriaOnly', true);
+
+                // Merge the bindings we get from nestedCriteria object
+                $bindings[] = $queryObject->getBindings();
+
+                // Append the sql we get from the nestedCriteria object
+                $criteria .= $statement['joiner'] . ' (' . $queryObject->getSql() . ') ';
+
+                continue;
+            }
+
+            if (is_array($value) === true) {
+
+                // Where in or between like query
+                $criteria .= $statement['joiner'] . ' ' . $key . ' ' . $statement['operator'];
+
+                if ($statement['operator'] === 'BETWEEN') {
+                    $bindings[] = [$statement['value']];
+                    $criteria .= ' ? AND ? ';
+                } else {
+                    $valuePlaceholder = '';
+                    foreach ((array)$statement['value'] as $subValue) {
+                        $valuePlaceholder .= '?, ';
+                        $bindings[] = [$subValue];
+                    }
+
+                    $valuePlaceholder = trim($valuePlaceholder, ', ');
+                    $criteria .= ' (' . $valuePlaceholder . ') ';
+                }
+
+                continue;
+
+            }
+
+            if ($value instanceof Raw) {
+                $criteria .= "{$statement['joiner']} {$key} {$statement['operator']} $value ";
+                continue;
+            }
+
+
+            // Usual where like criteria
+            if ($bindValues === false) {
+
+                // Specially for joins - we are not binding values, lets sanitize then
+                $value = $this->wrapSanitizer($value);
+                $criteria .= $statement['joiner'] . ' ' . $key . ' ' . $statement['operator'] . ' ' . $value . ' ';
+
+                continue;
+            }
+
+            if ($statement['key'] instanceof Raw) {
+
+                if ($statement['operator'] !== null) {
+                    $criteria .= "{$statement['joiner']} {$key} {$statement['operator']} ? ";
+                    $bindings[] = $statement['key']->getBindings();
+                    $bindings[] = [$value];
+                } else {
+                    $criteria .= $statement['joiner'] . ' ' . $key . ' ';
+                    $bindings[] = $statement['key']->getBindings();
+                }
+
+                continue;
+
+            }
+
+            // WHERE
+            $valuePlaceholder = '?';
+            $bindings[] = [$value];
+            $criteria .= $statement['joiner'] . ' ' . $key . ' ' . $statement['operator'] . ' ' . $valuePlaceholder . ' ';
+        }
+
+        // Clear all white spaces, and, or from beginning and white spaces from ending
+        $criteria = preg_replace('/^(\s?AND ?|\s?OR ?)|\s$/i', '', $criteria);
+
+        return [$criteria, array_merge(...$bindings)];
+    }
+
+    /**
+     * Build criteria string and binding with various types added, like WHERE and Having
+     *
+     * @param array $statements
+     * @param string $key
+     * @param string $type
+     * @param bool $bindValues
+     * @return array
+     * @throws Exception
+     */
+    protected function buildCriteriaWithType(array $statements, $key, $type, $bindValues = true)
+    {
+        $criteria = '';
+        $bindings = [];
+
+        if (isset($statements[$key]) === true) {
+            // Get the generic/adapter agnostic criteria string from parent
+            list($criteria, $bindings) = $this->buildCriteria($statements[$key], $bindValues);
+
+            if ($criteria !== null) {
+                $criteria = $type . ' ' . $criteria;
+            }
+        }
+
+        return [$criteria, $bindings];
+    }
+
+    /**
+     * Build join string
+     *
+     * @param array $statements
+     * @return string
+     * @throws Exception
+     */
+    protected function buildJoin(array $statements)
+    {
+        $sql = '';
+
+        if (\array_key_exists('joins', $statements) === false || \count($statements['joins']) === 0) {
+            return $sql;
+        }
+
+        foreach ((array)$statements['joins'] as $joinArr) {
+            if (\is_array($joinArr['table']) === true) {
+                list($mainTable, $aliasTable) = $joinArr['table'];
+                $table = $this->wrapSanitizer($mainTable) . ' AS ' . $this->wrapSanitizer($aliasTable);
+            } else {
+                $table = $joinArr['table'] instanceof Raw ? (string)$joinArr['table'] : $this->wrapSanitizer($joinArr['table']);
+            }
+
+            /* @var $joinBuilder \Pecee\Pixie\QueryBuilder\QueryBuilderHandler */
+            $joinBuilder = $joinArr['joinBuilder'];
+
+            $sqlArr = [
+                $sql,
+                strtoupper($joinArr['type']),
+                'JOIN',
+                $table,
+                'ON',
+                $joinBuilder->getQuery('criteriaOnly', false)->getSql(),
+            ];
+
+            $sql = $this->concatenateQuery($sqlArr);
+        }
+
+        return $sql;
+    }
+
+    /**
+     * Join different part of queries with a space.
+     *
+     * @param array $pieces
+     * @return string
+     */
+    protected function concatenateQuery(array $pieces)
+    {
+        $str = '';
+        foreach ($pieces as $piece) {
+            $str = trim($str) . ' ' . trim($piece);
+        }
+
+        return trim($str);
+    }
+
+    /**
+     * Build just criteria part of the query
+     *
+     * @param array $statements
+     * @param bool $bindValues
+     * @return array
+     * @throws Exception
+     */
+    public function criteriaOnly(array $statements, $bindValues = true)
+    {
+        $sql = $bindings = [];
+        if (isset($statements['criteria']) === false) {
+            return compact('sql', 'bindings');
+        }
+
+        list($sql, $bindings) = $this->buildCriteria($statements['criteria'], $bindValues);
+
+        return compact('sql', 'bindings');
+    }
+
+    /**
+     * Build delete query
+     *
+     * @param array $statements
+     * @return array
+     * @throws Exception
+     */
+    public function delete(array $statements)
+    {
+        $table = end($statements['tables']);
+
+        // WHERE
+        list($whereCriteria, $whereBindings) = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
+
+        $sqlArray = ['DELETE FROM', $this->wrapSanitizer($table), $whereCriteria];
+        $sql = $this->concatenateQuery($sqlArray);
+        $bindings = $whereBindings;
+
+        return compact('sql', 'bindings');
+    }
+
+    /**
+     * Build a generic insert/ignore/replace query
+     *
+     * @param array $statements
+     * @param array $data
+     * @param string $type
+     * @return array
+     * @throws Exception
+     */
+    private function doInsert(array $statements, array $data, $type)
+    {
+        $table = end($statements['tables']);
+
+        $bindings = $keys = $values = [];
+
+        foreach ($data as $key => $value) {
+            $keys[] = $key;
+            if ($value instanceof Raw) {
+                $values[] = (string)$value;
+            } else {
+                $values[] = '?';
+                $bindings[] = $value;
+            }
+        }
+
+        $sqlArray = [
+            $type . ' INTO',
+            $this->wrapSanitizer($table),
+            '(' . $this->arrayStr($keys) . ')',
+            'VALUES',
+            '(' . $this->arrayStr($values, ',', false) . ')',
+        ];
+
+        if (isset($statements['onduplicate']) === true) {
+
+            if (\count($statements['onduplicate']) < 1) {
+                throw new Exception('No data given.', 4);
+            }
+
+            list($updateStatement, $updateBindings) = $this->getUpdateStatement($statements['onduplicate']);
+            $sqlArray[] = 'ON DUPLICATE KEY UPDATE ' . $updateStatement;
+            $bindings = array_merge($bindings, $updateBindings);
+
+        }
+
+        $sql = $this->concatenateQuery($sqlArray);
+
+        return compact('sql', 'bindings');
+    }
+
+    /**
+     * Build fields assignment part of SET ... or ON DUBLICATE KEY UPDATE ... statements
+     *
+     * @param array $data
+     * @return array
+     */
+    private function getUpdateStatement(array $data)
+    {
+        $bindings = [];
+        $statement = '';
+
+        foreach ($data as $key => $value) {
+
+            $statement .= $this->wrapSanitizer($key) . '=';
+
+            if ($value instanceof Raw) {
+                $statement .= $value . ',';
+            } else {
+                $statement .= '?,';
+                $bindings[] = $value;
+            }
+        }
+
+        $statement = trim($statement, ',');
+
+        return [$statement, $bindings];
+    }
+
+    /**
+     * Build insert query
+     *
+     * @param array $statements
+     * @param array $data
+     * @return array
+     * @throws Exception
+     */
+    public function insert(array $statements, array $data)
+    {
+        return $this->doInsert($statements, $data, 'INSERT');
+    }
+
+    /**
+     * Build insert and ignore query
+     *
+     * @param array $statements
+     * @param array $data
+     * @return array
+     * @throws Exception
+     */
+    public function insertIgnore(array $statements, array $data)
+    {
+        return $this->doInsert($statements, $data, 'INSERT IGNORE');
+    }
+
+    /**
+     * Build replace query
+     *
+     * @param array $statements
+     * @param array $data
+     * @return array
+     * @throws Exception
+     */
+    public function replace(array $statements, array $data)
+    {
+        return $this->doInsert($statements, $data, 'REPLACE');
     }
 
     /**
@@ -50,7 +422,7 @@ abstract class BaseAdapter
     public function select(array $statements)
     {
         if (array_key_exists('selects', $statements) === false) {
-            $statements['selects'][] = '*';
+            $statements['selects'] = ['*'];
         }
 
         // From
@@ -61,13 +433,16 @@ abstract class BaseAdapter
             $tables = [];
 
             foreach ((array)$statements['tables'] as $table) {
-
-                $prefix = isset($statements['aliases'][$table]) ? $statements['aliases'][$table] : null;
-
-                if ($prefix !== null) {
-                    $t = ($table instanceof Raw) ? $table : '`' . $table . '` AS `' . strtolower($prefix) . '`';
+                if ($table instanceof Raw) {
+                    $t = $table;
                 } else {
-                    $t = ($table instanceof Raw) ? $table : '`' . $table . '`';
+                    $prefix = isset($statements['aliases'][$table]) ? $statements['aliases'][$table] : null;
+
+                    if ($prefix !== null) {
+                        $t = sprintf('`%s` AS `%s`', $table, strtolower($prefix));
+                    } else {
+                        $t = sprintf('`%s`', $table);
+                    }
                 }
 
                 $tables[] = $t;
@@ -91,7 +466,7 @@ abstract class BaseAdapter
 
         // ORDER BY
         $orderBys = '';
-        if (isset($statements['orderBys']) && is_array($statements['orderBys'])) {
+        if (isset($statements['orderBys']) && \is_array($statements['orderBys'])) {
             foreach ($statements['orderBys'] as $orderBy) {
                 $orderBys .= $this->wrapSanitizer($orderBy['field']) . ' ' . $orderBy['type'] . ', ';
             }
@@ -136,143 +511,6 @@ abstract class BaseAdapter
     }
 
     /**
-     * Build just criteria part of the query
-     *
-     * @param array $statements
-     * @param bool $bindValues
-     * @return array
-     * @throws Exception
-     */
-    public function criteriaOnly(array $statements, $bindValues = true)
-    {
-        $sql = $bindings = [];
-        if (isset($statements['criteria']) === false) {
-            return compact('sql', 'bindings');
-        }
-
-        list($sql, $bindings) = $this->buildCriteria($statements['criteria'], $bindValues);
-
-        return compact('sql', 'bindings');
-    }
-
-    /**
-     * Build a generic insert/ignore/replace query
-     *
-     * @param array $statements
-     * @param array $data
-     * @param string $type
-     * @return array
-     * @throws Exception
-     */
-    private function doInsert(array $statements, array $data, $type)
-    {
-        $table = end($statements['tables']);
-
-        $bindings = $keys = $values = [];
-
-        foreach ($data as $key => $value) {
-            $keys[] = $key;
-            if ($value instanceof Raw) {
-                $values[] = (string)$value;
-            } else {
-                $values[] = '?';
-                $bindings[] = $value;
-            }
-        }
-
-        $sqlArray = [
-            $type . ' INTO',
-            $this->wrapSanitizer($table),
-            '(' . $this->arrayStr($keys) . ')',
-            'VALUES',
-            '(' . $this->arrayStr($values, ',', false) . ')',
-        ];
-
-        if (isset($statements['onduplicate']) === true) {
-
-            if (count($statements['onduplicate']) < 1) {
-                throw new Exception('No data given.', 4);
-            }
-
-            list($updateStatement, $updateBindings) = $this->getUpdateStatement($statements['onduplicate']);
-            $sqlArray[] = 'ON DUPLICATE KEY UPDATE ' . $updateStatement;
-            $bindings = array_merge($bindings, $updateBindings);
-
-        }
-
-        $sql = $this->concatenateQuery($sqlArray);
-
-        return compact('sql', 'bindings');
-    }
-
-    /**
-     * Build insert query
-     *
-     * @param array $statements
-     * @param array $data
-     * @return array
-     * @throws Exception
-     */
-    public function insert(array $statements, array $data)
-    {
-        return $this->doInsert($statements, $data, 'INSERT');
-    }
-
-    /**
-     * Build insert and ignore query
-     *
-     * @param array $statements
-     * @param array $data
-     * @return array
-     * @throws Exception
-     */
-    public function insertIgnore(array $statements, array $data)
-    {
-        return $this->doInsert($statements, $data, 'INSERT IGNORE');
-    }
-
-    /**
-     * Build replace query
-     *
-     * @param array $statements
-     * @param array $data
-     * @return array
-     * @throws Exception
-     */
-    public function replace(array $statements, array $data)
-    {
-        return $this->doInsert($statements, $data, 'REPLACE');
-    }
-
-    /**
-     * Build fields assignment part of SET ... or ON DUBLICATE KEY UPDATE ... statements
-     *
-     * @param array $data
-     * @return array
-     */
-    private function getUpdateStatement(array $data)
-    {
-        $bindings = [];
-        $statement = '';
-
-        foreach ($data as $key => $value) {
-
-            $statement .= $this->wrapSanitizer($key) . '=';
-
-            if ($value instanceof Raw) {
-                $statement .= $value . ',';
-            } else {
-                $statement .= '?,';
-                $bindings[] = $value;
-            }
-        }
-
-        $statement = trim($statement, ',');
-
-        return [$statement, $bindings];
-    }
-
-    /**
      * Build update query
      *
      * @param array $statements
@@ -313,184 +551,6 @@ abstract class BaseAdapter
     }
 
     /**
-     * Build delete query
-     *
-     * @param array $statements
-     * @return array
-     * @throws Exception
-     */
-    public function delete(array $statements)
-    {
-        $table = end($statements['tables']);
-
-        // WHERE
-        list($whereCriteria, $whereBindings) = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
-
-        $sqlArray = ['DELETE FROM', $this->wrapSanitizer($table), $whereCriteria];
-        $sql = $this->concatenateQuery($sqlArray);
-        $bindings = $whereBindings;
-
-        return compact('sql', 'bindings');
-    }
-
-    /**
-     * Array concatenating method, like implode.
-     * But it does wrap sanitizer and trims last glue
-     *
-     * @param array $pieces
-     * @param string $glue
-     * @param bool $wrapSanitizer
-     * @return string
-     */
-    protected function arrayStr(array $pieces, $glue = ',', $wrapSanitizer = true)
-    {
-        $str = '';
-        foreach ($pieces as $key => $piece) {
-            if ($wrapSanitizer === true) {
-                $piece = $this->wrapSanitizer($piece);
-            }
-
-            if (is_int($key) === false) {
-                $piece = ($wrapSanitizer ? $this->wrapSanitizer($key) : $key) . ' AS ' . $piece;
-            }
-
-            $str .= $piece . $glue;
-        }
-
-        return trim($str, $glue);
-    }
-
-    /**
-     * Join different part of queries with a space.
-     *
-     * @param array $pieces
-     * @return string
-     */
-    protected function concatenateQuery(array $pieces)
-    {
-        $str = '';
-        foreach ($pieces as $piece) {
-            $str = trim($str) . ' ' . trim($piece);
-        }
-
-        return trim($str);
-    }
-
-    /**
-     * Build generic criteria string and bindings from statements, like "a = b and c = ?"
-     *
-     * @param array $statements
-     * @param bool $bindValues
-     * @throws Exception
-     * @return array
-     */
-    protected function buildCriteria(array $statements, $bindValues = true)
-    {
-        $criteria = '';
-        $bindings = [[]];
-
-        foreach ($statements as $statement) {
-
-            $key = $this->wrapSanitizer($statement['key']);
-            $value = $statement['value'];
-
-            if ($value === null && $key instanceof \Closure) {
-
-                /**
-                 * We have a closure, a nested criteria
-                 * Build a new NestedCriteria class, keep it by reference so any changes made in the closure should reflect here
-                 */
-
-                /* @var $nestedCriteria NestedCriteria */
-                $nestedCriteria = $this->container->build(
-                    NestedCriteria::class,
-                    [$this->connection]
-                );
-
-                // Call the closure with our new nestedCriteria object
-                $key($nestedCriteria);
-
-                // Get the criteria only query from the nestedCriteria object
-                $queryObject = $nestedCriteria->getQuery('criteriaOnly', true);
-
-                // Merge the bindings we get from nestedCriteria object
-                $bindings[] = $queryObject->getBindings();
-
-                // Append the sql we get from the nestedCriteria object
-                $criteria .= $statement['joiner'] . ' (' . $queryObject->getSql() . ') ';
-
-                continue;
-            }
-
-            if (is_array($value) === true) {
-
-                // Where in or between like query
-                $criteria .= $statement['joiner'] . ' ' . $key . ' ' . $statement['operator'];
-
-                if ($statement['operator'] === 'BETWEEN') {
-                    $bindings[] = (array)$statement['value'];
-                    $criteria .= ' ? AND ? ';
-                } else {
-                    $valuePlaceholder = '';
-                    foreach ((array)$statement['value'] as $subValue) {
-                        $valuePlaceholder .= '?, ';
-                        $bindings[] = (array)$subValue;
-                    }
-
-                    $valuePlaceholder = trim($valuePlaceholder, ', ');
-                    $criteria .= ' (' . $valuePlaceholder . ') ';
-                }
-
-                continue;
-
-            }
-
-            if ($value instanceof Raw) {
-                $criteria .= "{$statement['joiner']} {$key} {$statement['operator']} $value ";
-                continue;
-            }
-
-
-            // Usual where like criteria
-            if ($bindValues === false) {
-
-                // Specially for joins - we are not binding values, lets sanitize then
-                $value = $this->wrapSanitizer($value);
-                $criteria .= $statement['joiner'] . ' ' . $key . ' ' . $statement['operator'] . ' ' . $value . ' ';
-
-                continue;
-            }
-
-            if ($statement['key'] instanceof Raw) {
-
-                if ($statement['operator'] !== null) {
-                    $criteria .= "{$statement['joiner']} {$key} {$statement['operator']} ? ";
-                    $bindings[] = (array)$statement['key']->getBindings();
-                    $bindings[] = (array)$value;
-                } else {
-                    $criteria .= $statement['joiner'] . ' ' . $key . ' ';
-                    $bindings[] = (array)$statement['key']->getBindings();
-                }
-
-                continue;
-
-            }
-
-            // WHERE
-            $valuePlaceholder = '?';
-            $bindings[] = [$value];
-            $criteria .= $statement['joiner'] . ' ' . $key . ' ' . $statement['operator'] . ' ' . $valuePlaceholder . ' ';
-        }
-
-        $bindings = array_merge(...$bindings);
-
-        // Clear all white spaces, and, or from beginning and white spaces from ending
-        $criteria = preg_replace('/^(\s?AND ?|\s?OR ?)|\s$/i', '', $criteria);
-
-        return [$criteria, $bindings];
-    }
-
-    /**
      * Wrap values with adapter's sanitizer like, '`'
      *
      * @param string|Raw|\Closure $value
@@ -519,71 +579,4 @@ abstract class BaseAdapter
         return implode('.', $valueArr);
     }
 
-    /**
-     * Build criteria string and binding with various types added, like WHERE and Having
-     *
-     * @param array $statements
-     * @param string $key
-     * @param string $type
-     * @param bool $bindValues
-     * @return array
-     * @throws Exception
-     */
-    protected function buildCriteriaWithType(array $statements, $key, $type, $bindValues = true)
-    {
-        $criteria = '';
-        $bindings = [];
-
-        if (isset($statements[$key]) === true) {
-            // Get the generic/adapter agnostic criteria string from parent
-            list($criteria, $bindings) = $this->buildCriteria($statements[$key], $bindValues);
-
-            if ($criteria !== null) {
-                $criteria = $type . ' ' . $criteria;
-            }
-        }
-
-        return [$criteria, $bindings];
-    }
-
-    /**
-     * Build join string
-     *
-     * @param array $statements
-     * @return string
-     * @throws Exception
-     */
-    protected function buildJoin(array $statements)
-    {
-        $sql = '';
-
-        if (array_key_exists('joins', $statements) === false || count($statements['joins']) === 0) {
-            return $sql;
-        }
-
-        foreach ((array)$statements['joins'] as $joinArr) {
-            if (is_array($joinArr['table']) === true) {
-                list($mainTable, $aliasTable) = $joinArr['table'];
-                $table = $this->wrapSanitizer($mainTable) . ' AS ' . $this->wrapSanitizer($aliasTable);
-            } else {
-                $table = $joinArr['table'] instanceof Raw ? (string)$joinArr['table'] : $this->wrapSanitizer($joinArr['table']);
-            }
-
-            /* @var $joinBuilder \Pecee\Pixie\QueryBuilder\QueryBuilderHandler */
-            $joinBuilder = $joinArr['joinBuilder'];
-
-            $sqlArr = [
-                $sql,
-                strtoupper($joinArr['type']),
-                'JOIN',
-                $table,
-                'ON',
-                $joinBuilder->getQuery('criteriaOnly', false)->getSql(),
-            ];
-
-            $sql = $this->concatenateQuery($sqlArr);
-        }
-
-        return $sql;
-    }
 }

--- a/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -12,571 +12,569 @@ use Pecee\Pixie\QueryBuilder\Raw;
  *
  * @package Pecee\Pixie\QueryBuilder\Adapters
  */
-abstract class BaseAdapter
-{
-    /**
-     * @var string
-     */
-    const SANITIZER = '`';
-
-    /**
-     * @var \Pecee\Pixie\Connection
-     */
-    protected $connection;
-
-    /**
-     * BaseAdapter constructor.
-     *
-     * @param \Pecee\Pixie\Connection $connection
-     */
-    public function __construct(Connection $connection)
-    {
-        $this->connection = $connection;
-    }
-
-    /**
-     * Array concatenating method, like implode.
-     * But it does wrap sanitizer and trims last glue
-     *
-     * @param array $pieces
-     * @param string $glue
-     * @param bool $wrapSanitizer
-     * @return string
-     */
-    protected function arrayStr(array $pieces, $glue = ',', $wrapSanitizer = true)
-    {
-        $str = '';
-        foreach ($pieces as $key => $piece) {
-            if ($wrapSanitizer === true) {
-                $piece = $this->wrapSanitizer($piece);
-            }
-
-            if (\is_int($key) === false) {
-                $piece = ($wrapSanitizer ? $this->wrapSanitizer($key) : $key) . ' AS ' . $piece;
-            }
-
-            $str .= $piece . $glue;
-        }
-
-        return trim($str, $glue);
-    }
-
-    /**
-     * Build generic criteria string and bindings from statements, like "a = b and c = ?"
-     *
-     * @param array $statements
-     * @param bool $bindValues
-     * @throws Exception
-     * @return array
-     */
-    protected function buildCriteria(array $statements, $bindValues = true)
-    {
-        $criteria = '';
-        $bindings = [[]];
-
-        foreach ($statements as $statement) {
-
-            $key = $this->wrapSanitizer($statement['key']);
-            $value = $statement['value'];
-
-            if ($value === null && $key instanceof \Closure) {
-
-                /**
-                 * We have a closure, a nested criteria
-                 * Build a new NestedCriteria class, keep it by reference so any changes made in the closure should reflect here
-                 */
-
-                /* @var $nestedCriteria NestedCriteria */
-                $nestedCriteria = new NestedCriteria($this->connection);
-
-                // Call the closure with our new nestedCriteria object
-                $key($nestedCriteria);
-
-                // Get the criteria only query from the nestedCriteria object
-                $queryObject = $nestedCriteria->getQuery('criteriaOnly', true);
-
-                // Merge the bindings we get from nestedCriteria object
-                $bindings[] = $queryObject->getBindings();
-
-                // Append the sql we get from the nestedCriteria object
-                $criteria .= $statement['joiner'] . ' (' . $queryObject->getSql() . ') ';
-
-                continue;
-            }
-
-            if (is_array($value) === true) {
-
-                // Where in or between like query
-                $criteria .= $statement['joiner'] . ' ' . $key . ' ' . $statement['operator'];
-
-                if ($statement['operator'] === 'BETWEEN') {
-                    $bindings[] = [$statement['value']];
-                    $criteria .= ' ? AND ? ';
-                } else {
-                    $valuePlaceholder = '';
-                    foreach ((array)$statement['value'] as $subValue) {
-                        $valuePlaceholder .= '?, ';
-                        $bindings[] = [$subValue];
-                    }
-
-                    $valuePlaceholder = trim($valuePlaceholder, ', ');
-                    $criteria .= ' (' . $valuePlaceholder . ') ';
-                }
-
-                continue;
-
-            }
-
-            if ($value instanceof Raw) {
-                $criteria .= "{$statement['joiner']} {$key} {$statement['operator']} $value ";
-                continue;
-            }
-
-
-            // Usual where like criteria
-            if ($bindValues === false) {
-
-                // Specially for joins - we are not binding values, lets sanitize then
-                $value = $this->wrapSanitizer($value);
-                $criteria .= $statement['joiner'] . ' ' . $key . ' ' . $statement['operator'] . ' ' . $value . ' ';
-
-                continue;
-            }
-
-            if ($statement['key'] instanceof Raw) {
-
-                if ($statement['operator'] !== null) {
-                    $criteria .= "{$statement['joiner']} {$key} {$statement['operator']} ? ";
-                    $bindings[] = $statement['key']->getBindings();
-                    $bindings[] = [$value];
-                } else {
-                    $criteria .= $statement['joiner'] . ' ' . $key . ' ';
-                    $bindings[] = $statement['key']->getBindings();
-                }
-
-                continue;
-
-            }
-
-            // WHERE
-            $valuePlaceholder = '?';
-            $bindings[] = [$value];
-            $criteria .= $statement['joiner'] . ' ' . $key . ' ' . $statement['operator'] . ' ' . $valuePlaceholder . ' ';
-        }
-
-        // Clear all white spaces, and, or from beginning and white spaces from ending
-        $criteria = preg_replace('/^(\s?AND ?|\s?OR ?)|\s$/i', '', $criteria);
-
-        return [$criteria, array_merge(...$bindings)];
-    }
-
-    /**
-     * Build criteria string and binding with various types added, like WHERE and Having
-     *
-     * @param array $statements
-     * @param string $key
-     * @param string $type
-     * @param bool $bindValues
-     * @return array
-     * @throws Exception
-     */
-    protected function buildCriteriaWithType(array $statements, $key, $type, $bindValues = true)
-    {
-        $criteria = '';
-        $bindings = [];
-
-        if (isset($statements[$key]) === true) {
-            // Get the generic/adapter agnostic criteria string from parent
-            list($criteria, $bindings) = $this->buildCriteria($statements[$key], $bindValues);
-
-            if ($criteria !== null) {
-                $criteria = $type . ' ' . $criteria;
-            }
-        }
-
-        return [$criteria, $bindings];
-    }
-
-    /**
-     * Build join string
-     *
-     * @param array $statements
-     * @return string
-     * @throws Exception
-     */
-    protected function buildJoin(array $statements)
-    {
-        $sql = '';
-
-        if (\array_key_exists('joins', $statements) === false || \count($statements['joins']) === 0) {
-            return $sql;
-        }
-
-        foreach ((array)$statements['joins'] as $joinArr) {
-            if (\is_array($joinArr['table']) === true) {
-                list($mainTable, $aliasTable) = $joinArr['table'];
-                $table = $this->wrapSanitizer($mainTable) . ' AS ' . $this->wrapSanitizer($aliasTable);
-            } else {
-                $table = $joinArr['table'] instanceof Raw ? (string)$joinArr['table'] : $this->wrapSanitizer($joinArr['table']);
-            }
-
-            /* @var $joinBuilder \Pecee\Pixie\QueryBuilder\QueryBuilderHandler */
-            $joinBuilder = $joinArr['joinBuilder'];
-
-            $sqlArr = [
-                $sql,
-                strtoupper($joinArr['type']),
-                'JOIN',
-                $table,
-                'ON',
-                $joinBuilder->getQuery('criteriaOnly', false)->getSql(),
-            ];
-
-            $sql = $this->concatenateQuery($sqlArr);
-        }
-
-        return $sql;
-    }
-
-    /**
-     * Join different part of queries with a space.
-     *
-     * @param array $pieces
-     * @return string
-     */
-    protected function concatenateQuery(array $pieces)
-    {
-        $str = '';
-        foreach ($pieces as $piece) {
-            $str = trim($str) . ' ' . trim($piece);
-        }
-
-        return trim($str);
-    }
-
-    /**
-     * Build just criteria part of the query
-     *
-     * @param array $statements
-     * @param bool $bindValues
-     * @return array
-     * @throws Exception
-     */
-    public function criteriaOnly(array $statements, $bindValues = true)
-    {
-        $sql = $bindings = [];
-        if (isset($statements['criteria']) === false) {
-            return compact('sql', 'bindings');
-        }
-
-        list($sql, $bindings) = $this->buildCriteria($statements['criteria'], $bindValues);
-
-        return compact('sql', 'bindings');
-    }
-
-    /**
-     * Build delete query
-     *
-     * @param array $statements
-     * @return array
-     * @throws Exception
-     */
-    public function delete(array $statements)
-    {
-        $table = end($statements['tables']);
-
-        // WHERE
-        list($whereCriteria, $whereBindings) = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
-
-        $sqlArray = ['DELETE FROM', $this->wrapSanitizer($table), $whereCriteria];
-        $sql = $this->concatenateQuery($sqlArray);
-        $bindings = $whereBindings;
-
-        return compact('sql', 'bindings');
-    }
-
-    /**
-     * Build a generic insert/ignore/replace query
-     *
-     * @param array $statements
-     * @param array $data
-     * @param string $type
-     * @return array
-     * @throws Exception
-     */
-    private function doInsert(array $statements, array $data, $type)
-    {
-        $table = end($statements['tables']);
-
-        $bindings = $keys = $values = [];
-
-        foreach ($data as $key => $value) {
-            $keys[] = $key;
-            if ($value instanceof Raw) {
-                $values[] = (string)$value;
-            } else {
-                $values[] = '?';
-                $bindings[] = $value;
-            }
-        }
-
-        $sqlArray = [
-            $type . ' INTO',
-            $this->wrapSanitizer($table),
-            '(' . $this->arrayStr($keys) . ')',
-            'VALUES',
-            '(' . $this->arrayStr($values, ',', false) . ')',
-        ];
-
-        if (isset($statements['onduplicate']) === true) {
-
-            if (\count($statements['onduplicate']) < 1) {
-                throw new Exception('No data given.', 4);
-            }
-
-            list($updateStatement, $updateBindings) = $this->getUpdateStatement($statements['onduplicate']);
-            $sqlArray[] = 'ON DUPLICATE KEY UPDATE ' . $updateStatement;
-            $bindings = array_merge($bindings, $updateBindings);
-
-        }
-
-        $sql = $this->concatenateQuery($sqlArray);
-
-        return compact('sql', 'bindings');
-    }
-
-    /**
-     * Build fields assignment part of SET ... or ON DUBLICATE KEY UPDATE ... statements
-     *
-     * @param array $data
-     * @return array
-     */
-    private function getUpdateStatement(array $data)
-    {
-        $bindings = [];
-        $statement = '';
-
-        foreach ($data as $key => $value) {
-
-            $statement .= $this->wrapSanitizer($key) . '=';
-
-            if ($value instanceof Raw) {
-                $statement .= $value . ',';
-            } else {
-                $statement .= '?,';
-                $bindings[] = $value;
-            }
-        }
-
-        $statement = trim($statement, ',');
-
-        return [$statement, $bindings];
-    }
-
-    /**
-     * Build insert query
-     *
-     * @param array $statements
-     * @param array $data
-     * @return array
-     * @throws Exception
-     */
-    public function insert(array $statements, array $data)
-    {
-        return $this->doInsert($statements, $data, 'INSERT');
-    }
-
-    /**
-     * Build insert and ignore query
-     *
-     * @param array $statements
-     * @param array $data
-     * @return array
-     * @throws Exception
-     */
-    public function insertIgnore(array $statements, array $data)
-    {
-        return $this->doInsert($statements, $data, 'INSERT IGNORE');
-    }
-
-    /**
-     * Build replace query
-     *
-     * @param array $statements
-     * @param array $data
-     * @return array
-     * @throws Exception
-     */
-    public function replace(array $statements, array $data)
-    {
-        return $this->doInsert($statements, $data, 'REPLACE');
-    }
-
-    /**
-     * Build select query string and bindings
-     *
-     * @param array $statements
-     * @throws Exception
-     * @return array
-     */
-    public function select(array $statements)
-    {
-        if (array_key_exists('selects', $statements) === false) {
-            $statements['selects'] = ['*'];
-        }
-
-        // From
-        $fromEnabled = false;
-        $tables = '';
-
-        if (isset($statements['tables']) === true) {
-            $tables = [];
-
-            foreach ((array)$statements['tables'] as $table) {
-                if ($table instanceof Raw) {
-                    $t = $table;
-                } else {
-                    $prefix = isset($statements['aliases'][$table]) ? $statements['aliases'][$table] : null;
-
-                    if ($prefix !== null) {
-                        $t = sprintf('`%s` AS `%s`', $table, strtolower($prefix));
-                    } else {
-                        $t = sprintf('`%s`', $table);
-                    }
-                }
-
-                $tables[] = $t;
-            }
-
-            $tables = implode(',', $tables);
-            $fromEnabled = true;
-        }
-
-        // SELECT
-        $selects = $this->arrayStr($statements['selects'], ', ');
-
-        // WHERE
-        list($whereCriteria, $whereBindings) = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
-
-        // GROUP BY
-        $groupBys = $this->arrayStr($statements['groupBys'], ', ');
-        if ($groupBys !== '' && isset($statements['groupBys']) === true) {
-            $groupBys = 'GROUP BY ' . $groupBys;
-        }
-
-        // ORDER BY
-        $orderBys = '';
-        if (isset($statements['orderBys']) && \is_array($statements['orderBys'])) {
-            foreach ($statements['orderBys'] as $orderBy) {
-                $orderBys .= $this->wrapSanitizer($orderBy['field']) . ' ' . $orderBy['type'] . ', ';
-            }
-
-            if ($orderBys = trim($orderBys, ', ')) {
-                $orderBys = 'ORDER BY ' . $orderBys;
-            }
-        }
-
-        // LIMIT AND OFFSET
-        $limit = isset($statements['limit']) ? 'LIMIT ' . $statements['limit'] : '';
-        $offset = isset($statements['offset']) ? 'OFFSET ' . $statements['offset'] : '';
-
-        // HAVING
-        list($havingCriteria, $havingBindings) = $this->buildCriteriaWithType($statements, 'havings', 'HAVING');
-
-        // JOINS
-        $joinString = $this->buildJoin($statements);
-
-        $sqlArray = [
-            'SELECT' . (isset($statements['distinct']) ? ' DISTINCT' : ''),
-            $selects,
-            $fromEnabled ? 'FROM' : '',
-            $tables,
-            $joinString,
-            $whereCriteria,
-            $groupBys,
-            $havingCriteria,
-            $orderBys,
-            $limit,
-            $offset,
-        ];
-
-        $sql = $this->concatenateQuery($sqlArray);
-
-        $bindings = array_merge(
-            $whereBindings,
-            $havingBindings
-        );
-
-        return compact('sql', 'bindings');
-    }
-
-    /**
-     * Build update query
-     *
-     * @param array $statements
-     * @param array $data
-     * @return array
-     * @throws Exception
-     */
-    public function update(array $statements, array $data)
-    {
-        if (count($data) < 1) {
-            throw new Exception('No data given.', 4);
-        }
-
-        $table = end($statements['tables']);
-
-        // UPDATE
-        list($updateStatement, $bindings) = $this->getUpdateStatement($data);
-
-        // WHERE
-        list($whereCriteria, $whereBindings) = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
-
-        // LIMIT
-        $limit = isset($statements['limit']) ? 'LIMIT ' . $statements['limit'] : '';
-
-        $sqlArray = [
-            'UPDATE',
-            $this->wrapSanitizer($table),
-            'SET ' . $updateStatement,
-            $whereCriteria,
-            $limit,
-        ];
-
-        $sql = $this->concatenateQuery($sqlArray);
-
-        $bindings = array_merge($bindings, $whereBindings);
-
-        return compact('sql', 'bindings');
-    }
-
-    /**
-     * Wrap values with adapter's sanitizer like, '`'
-     *
-     * @param string|Raw|\Closure $value
-     * @return string
-     */
-    public function wrapSanitizer($value)
-    {
-        // Its a raw query, just cast as string, object has __toString()
-        if ($value instanceof Raw) {
-            return (string)$value;
-        }
-
-        if ($value instanceof \Closure) {
-            return $value;
-        }
-
-        // Separate our table and fields which are joined with a ".", like my_table.id
-        $valueArr = explode('.', $value, 2);
-
-        foreach ($valueArr as $key => $subValue) {
-            // Don't wrap if we have *, which is not a usual field
-            $valueArr[$key] = trim($subValue) === '*' ? $subValue : static::SANITIZER . $subValue . static::SANITIZER;
-        }
-
-        // Join these back with "." and return
-        return implode('.', $valueArr);
-    }
+abstract class BaseAdapter {
+	/**
+	 * @var string
+	 */
+	const SANITIZER = '`';
+
+	/**
+	 * @var \Pecee\Pixie\Connection
+	 */
+	protected $connection;
+
+	/**
+	 * BaseAdapter constructor.
+	 *
+	 * @param \Pecee\Pixie\Connection $connection
+	 */
+	public function __construct(Connection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * Array concatenating method, like implode.
+	 * But it does wrap sanitizer and trims last glue
+	 *
+	 * @param array $pieces
+	 * @param string $glue
+	 * @param bool $wrapSanitizer
+	 *
+	 * @return string
+	 */
+	protected function arrayStr(array $pieces, $glue = ',', $wrapSanitizer = true) {
+		$str = '';
+		foreach ($pieces as $key => $piece) {
+			if ($wrapSanitizer === true) {
+				$piece = $this->wrapSanitizer($piece);
+			}
+
+			if (\is_int($key) === false) {
+				$piece = ($wrapSanitizer ? $this->wrapSanitizer($key) : $key) . ' AS ' . $piece;
+			}
+
+			$str .= $piece . $glue;
+		}
+
+		return trim($str, $glue);
+	}
+
+	/**
+	 * Build generic criteria string and bindings from statements, like "a = b and c = ?"
+	 *
+	 * @param array $statements
+	 * @param bool $bindValues
+	 *
+	 * @throws Exception
+	 * @return array
+	 */
+	protected function buildCriteria(array $statements, $bindValues = true) {
+		$criteria = '';
+		$bindings = [[]];
+
+		foreach ($statements as $statement) {
+
+			$key   = $this->wrapSanitizer($statement['key']);
+			$value = $statement['value'];
+
+			if ($value === null && $key instanceof \Closure) {
+
+				/**
+				 * We have a closure, a nested criteria
+				 * Build a new NestedCriteria class, keep it by reference so any changes made in the closure should reflect here
+				 */
+
+				/* @var $nestedCriteria NestedCriteria */
+				$nestedCriteria = new NestedCriteria($this->connection);
+
+				// Call the closure with our new nestedCriteria object
+				$key($nestedCriteria);
+
+				// Get the criteria only query from the nestedCriteria object
+				$queryObject = $nestedCriteria->getQuery('criteriaOnly', true);
+
+				// Merge the bindings we get from nestedCriteria object
+				$bindings[] = $queryObject->getBindings();
+
+				// Append the sql we get from the nestedCriteria object
+				$criteria .= $statement['joiner'] . ' (' . $queryObject->getSql() . ') ';
+
+				continue;
+			}
+
+			if (is_array($value) === true) {
+
+				// Where in or between like query
+				$criteria .= $statement['joiner'] . ' ' . $key . ' ' . $statement['operator'];
+
+				if ($statement['operator'] === 'BETWEEN') {
+					$bindings[] = [$statement['value']];
+					$criteria   .= ' ? AND ? ';
+				} else {
+					$valuePlaceholder = '';
+					foreach ((array)$statement['value'] as $subValue) {
+						$valuePlaceholder .= '?, ';
+						$bindings[]       = [$subValue];
+					}
+
+					$valuePlaceholder = trim($valuePlaceholder, ', ');
+					$criteria         .= ' (' . $valuePlaceholder . ') ';
+				}
+
+				continue;
+
+			}
+
+			if ($value instanceof Raw) {
+				$criteria .= "{$statement['joiner']} {$key} {$statement['operator']} $value ";
+				continue;
+			}
+
+
+			// Usual where like criteria
+			if ($bindValues === false) {
+
+				// Specially for joins - we are not binding values, lets sanitize then
+				$value    = $this->wrapSanitizer($value);
+				$criteria .= $statement['joiner'] . ' ' . $key . ' ' . $statement['operator'] . ' ' . $value . ' ';
+
+				continue;
+			}
+
+			if ($statement['key'] instanceof Raw) {
+
+				if ($statement['operator'] !== null) {
+					$criteria   .= "{$statement['joiner']} {$key} {$statement['operator']} ? ";
+					$bindings[] = $statement['key']->getBindings();
+					$bindings[] = [$value];
+				} else {
+					$criteria   .= $statement['joiner'] . ' ' . $key . ' ';
+					$bindings[] = $statement['key']->getBindings();
+				}
+
+				continue;
+
+			}
+
+			// WHERE
+			$valuePlaceholder = '?';
+			$bindings[]       = [$value];
+			$criteria         .= $statement['joiner'] . ' ' . $key . ' ' . $statement['operator'] . ' ' . $valuePlaceholder . ' ';
+		}
+
+		// Clear all white spaces, and, or from beginning and white spaces from ending
+		$criteria = preg_replace('/^(\s?AND ?|\s?OR ?)|\s$/i', '', $criteria);
+
+		return [$criteria, array_merge(...$bindings)];
+	}
+
+	/**
+	 * Build criteria string and binding with various types added, like WHERE and Having
+	 *
+	 * @param array $statements
+	 * @param string $key
+	 * @param string $type
+	 * @param bool $bindValues
+	 *
+	 * @return array
+	 * @throws Exception
+	 */
+	protected function buildCriteriaWithType(array $statements, $key, $type, $bindValues = true) {
+		$criteria = '';
+		$bindings = [];
+
+		if (isset($statements[ $key ]) === true) {
+			// Get the generic/adapter agnostic criteria string from parent
+			list($criteria, $bindings) = $this->buildCriteria($statements[ $key ], $bindValues);
+
+			if ($criteria !== null) {
+				$criteria = $type . ' ' . $criteria;
+			}
+		}
+
+		return [$criteria, $bindings];
+	}
+
+	/**
+	 * Build join string
+	 *
+	 * @param array $statements
+	 *
+	 * @return string
+	 * @throws Exception
+	 */
+	protected function buildJoin(array $statements) {
+		$sql = '';
+
+		if (\array_key_exists('joins', $statements) === false || \count($statements['joins']) === 0) {
+			return $sql;
+		}
+
+		foreach ((array)$statements['joins'] as $joinArr) {
+			if (\is_array($joinArr['table']) === true) {
+				list($mainTable, $aliasTable) = $joinArr['table'];
+				$table = $this->wrapSanitizer($mainTable) . ' AS ' . $this->wrapSanitizer($aliasTable);
+			} else {
+				$table = $joinArr['table'] instanceof Raw ? (string)$joinArr['table'] : $this->wrapSanitizer($joinArr['table']);
+			}
+
+			/* @var $joinBuilder \Pecee\Pixie\QueryBuilder\QueryBuilderHandler */
+			$joinBuilder = $joinArr['joinBuilder'];
+
+			$sqlArr = [
+				$sql,
+				strtoupper($joinArr['type']),
+				'JOIN',
+				$table,
+				'ON',
+				$joinBuilder->getQuery('criteriaOnly', false)->getSql(),
+			];
+
+			$sql = $this->concatenateQuery($sqlArr);
+		}
+
+		return $sql;
+	}
+
+	/**
+	 * Join different part of queries with a space.
+	 *
+	 * @param array $pieces
+	 *
+	 * @return string
+	 */
+	protected function concatenateQuery(array $pieces) {
+		$str = '';
+		foreach ($pieces as $piece) {
+			$str = trim($str) . ' ' . trim($piece);
+		}
+
+		return trim($str);
+	}
+
+	/**
+	 * Build just criteria part of the query
+	 *
+	 * @param array $statements
+	 * @param bool $bindValues
+	 *
+	 * @return array
+	 * @throws Exception
+	 */
+	public function criteriaOnly(array $statements, $bindValues = true) {
+		$sql = $bindings = [];
+		if (isset($statements['criteria']) === false) {
+			return compact('sql', 'bindings');
+		}
+
+		list($sql, $bindings) = $this->buildCriteria($statements['criteria'], $bindValues);
+
+		return compact('sql', 'bindings');
+	}
+
+	/**
+	 * Build delete query
+	 *
+	 * @param array $statements
+	 *
+	 * @return array
+	 * @throws Exception
+	 */
+	public function delete(array $statements) {
+		$table = end($statements['tables']);
+
+		// WHERE
+		list($whereCriteria, $whereBindings) = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
+
+		$sqlArray = ['DELETE FROM', $this->wrapSanitizer($table), $whereCriteria];
+		$sql      = $this->concatenateQuery($sqlArray);
+		$bindings = $whereBindings;
+
+		return compact('sql', 'bindings');
+	}
+
+	/**
+	 * Build a generic insert/ignore/replace query
+	 *
+	 * @param array $statements
+	 * @param array $data
+	 * @param string $type
+	 *
+	 * @return array
+	 * @throws Exception
+	 */
+	private function doInsert(array $statements, array $data, $type) {
+		$table = end($statements['tables']);
+
+		$bindings = $keys = $values = [];
+
+		foreach ($data as $key => $value) {
+			$keys[] = $key;
+			if ($value instanceof Raw) {
+				$values[] = (string)$value;
+			} else {
+				$values[]   = '?';
+				$bindings[] = $value;
+			}
+		}
+
+		$sqlArray = [
+			$type . ' INTO',
+			$this->wrapSanitizer($table),
+			'(' . $this->arrayStr($keys) . ')',
+			'VALUES',
+			'(' . $this->arrayStr($values, ',', false) . ')',
+		];
+
+		if (isset($statements['onduplicate']) === true) {
+
+			if (\count($statements['onduplicate']) < 1) {
+				throw new Exception('No data given.', 4);
+			}
+
+			list($updateStatement, $updateBindings) = $this->getUpdateStatement($statements['onduplicate']);
+			$sqlArray[] = 'ON DUPLICATE KEY UPDATE ' . $updateStatement;
+			$bindings   = array_merge($bindings, $updateBindings);
+
+		}
+
+		$sql = $this->concatenateQuery($sqlArray);
+
+		return compact('sql', 'bindings');
+	}
+
+	/**
+	 * Build fields assignment part of SET ... or ON DUBLICATE KEY UPDATE ... statements
+	 *
+	 * @param array $data
+	 *
+	 * @return array
+	 */
+	private function getUpdateStatement(array $data) {
+		$bindings  = [];
+		$statement = '';
+
+		foreach ($data as $key => $value) {
+
+			$statement .= $this->wrapSanitizer($key) . '=';
+
+			if ($value instanceof Raw) {
+				$statement .= $value . ',';
+			} else {
+				$statement  .= '?,';
+				$bindings[] = $value;
+			}
+		}
+
+		$statement = trim($statement, ',');
+
+		return [$statement, $bindings];
+	}
+
+	/**
+	 * Build insert query
+	 *
+	 * @param array $statements
+	 * @param array $data
+	 *
+	 * @return array
+	 * @throws Exception
+	 */
+	public function insert(array $statements, array $data) {
+		return $this->doInsert($statements, $data, 'INSERT');
+	}
+
+	/**
+	 * Build insert and ignore query
+	 *
+	 * @param array $statements
+	 * @param array $data
+	 *
+	 * @return array
+	 * @throws Exception
+	 */
+	public function insertIgnore(array $statements, array $data) {
+		return $this->doInsert($statements, $data, 'INSERT IGNORE');
+	}
+
+	/**
+	 * Build replace query
+	 *
+	 * @param array $statements
+	 * @param array $data
+	 *
+	 * @return array
+	 * @throws Exception
+	 */
+	public function replace(array $statements, array $data) {
+		return $this->doInsert($statements, $data, 'REPLACE');
+	}
+
+	/**
+	 * Build select query string and bindings
+	 *
+	 * @param array $statements
+	 *
+	 * @throws Exception
+	 * @return array
+	 */
+	public function select(array $statements) {
+		if (array_key_exists('selects', $statements) === false) {
+			$statements['selects'] = ['*'];
+		}
+
+		// From
+		$fromEnabled = false;
+		$tables      = '';
+
+		if (isset($statements['tables']) === true) {
+			$tables = [];
+
+			foreach ((array)$statements['tables'] as $table) {
+				if ($table instanceof Raw) {
+					$t = $table;
+				} else {
+					$prefix = isset($statements['aliases'][ $table ]) ? $statements['aliases'][ $table ] : null;
+
+					if ($prefix !== null) {
+						$t = sprintf('`%s` AS `%s`', $table, strtolower($prefix));
+					} else {
+						$t = sprintf('`%s`', $table);
+					}
+				}
+
+				$tables[] = $t;
+			}
+
+			$tables      = implode(',', $tables);
+			$fromEnabled = true;
+		}
+
+		// SELECT
+		$selects = $this->arrayStr($statements['selects'], ', ');
+
+		// WHERE
+		list($whereCriteria, $whereBindings) = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
+
+		// GROUP BY
+		$groupBys = $this->arrayStr($statements['groupBys'], ', ');
+		if ($groupBys !== '' && isset($statements['groupBys']) === true) {
+			$groupBys = 'GROUP BY ' . $groupBys;
+		}
+
+		// ORDER BY
+		$orderBys = '';
+		if (isset($statements['orderBys']) && \is_array($statements['orderBys'])) {
+			foreach ($statements['orderBys'] as $orderBy) {
+				$orderBys .= $this->wrapSanitizer($orderBy['field']) . ' ' . $orderBy['type'] . ', ';
+			}
+
+			if ($orderBys = trim($orderBys, ', ')) {
+				$orderBys = 'ORDER BY ' . $orderBys;
+			}
+		}
+
+		// LIMIT AND OFFSET
+		$limit  = isset($statements['limit']) ? 'LIMIT ' . $statements['limit'] : '';
+		$offset = isset($statements['offset']) ? 'OFFSET ' . $statements['offset'] : '';
+
+		// HAVING
+		list($havingCriteria, $havingBindings) = $this->buildCriteriaWithType($statements, 'havings', 'HAVING');
+
+		// JOINS
+		$joinString = $this->buildJoin($statements);
+
+		$sqlArray = [
+			'SELECT' . (isset($statements['distinct']) ? ' DISTINCT' : ''),
+			$selects,
+			$fromEnabled ? 'FROM' : '',
+			$tables,
+			$joinString,
+			$whereCriteria,
+			$groupBys,
+			$havingCriteria,
+			$orderBys,
+			$limit,
+			$offset,
+		];
+
+		$sql = $this->concatenateQuery($sqlArray);
+
+		$bindings = array_merge(
+			$whereBindings,
+			$havingBindings
+		);
+
+		return compact('sql', 'bindings');
+	}
+
+	/**
+	 * Build update query
+	 *
+	 * @param array $statements
+	 * @param array $data
+	 *
+	 * @return array
+	 * @throws Exception
+	 */
+	public function update(array $statements, array $data) {
+		if (count($data) < 1) {
+			throw new Exception('No data given.', 4);
+		}
+
+		$table = end($statements['tables']);
+
+		// UPDATE
+		list($updateStatement, $bindings) = $this->getUpdateStatement($data);
+
+		// WHERE
+		list($whereCriteria, $whereBindings) = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
+
+		// LIMIT
+		$limit = isset($statements['limit']) ? 'LIMIT ' . $statements['limit'] : '';
+
+		$sqlArray = [
+			'UPDATE',
+			$this->wrapSanitizer($table),
+			'SET ' . $updateStatement,
+			$whereCriteria,
+			$limit,
+		];
+
+		$sql = $this->concatenateQuery($sqlArray);
+
+		$bindings = array_merge($bindings, $whereBindings);
+
+		return compact('sql', 'bindings');
+	}
+
+	/**
+	 * Wrap values with adapter's sanitizer like, '`'
+	 *
+	 * @param string|Raw|\Closure $value
+	 *
+	 * @return string
+	 */
+	public function wrapSanitizer($value) {
+		// Its a raw query, just cast as string, object has __toString()
+		if ($value instanceof Raw) {
+			return (string)$value;
+		}
+
+		if ($value instanceof \Closure) {
+			return $value;
+		}
+
+		// Separate our table and fields which are joined with a ".", like my_table.id
+		$valueArr = explode('.', $value, 2);
+
+		foreach ($valueArr as $key => $subValue) {
+			// Don't wrap if we have *, which is not a usual field
+			$valueArr[ $key ] = trim($subValue) === '*' ? $subValue : static::SANITIZER . $subValue . static::SANITIZER;
+		}
+
+		// Join these back with "." and return
+		return implode('.', $valueArr);
+	}
 
 }

--- a/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -84,7 +84,6 @@ abstract class BaseAdapter {
 				 * Build a new NestedCriteria class, keep it by reference so any changes made in the closure should reflect here
 				 */
 
-				/* @var $nestedCriteria NestedCriteria */
 				$nestedCriteria = new NestedCriteria($this->connection);
 
 				// Call the closure with our new nestedCriteria object

--- a/src/Pecee/Pixie/QueryBuilder/Adapters/Mysql.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/Mysql.php
@@ -7,10 +7,9 @@ namespace Pecee\Pixie\QueryBuilder\Adapters;
  *
  * @package Pecee\Pixie\QueryBuilder\Adapters
  */
-class Mysql extends BaseAdapter
-{
-    /**
-     * @var string
-     */
-    const SANITIZER = '`';
+class Mysql extends BaseAdapter {
+	/**
+	 * @var string
+	 */
+	const SANITIZER = '`';
 }

--- a/src/Pecee/Pixie/QueryBuilder/Adapters/Pgsql.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/Pgsql.php
@@ -7,10 +7,9 @@ namespace Pecee\Pixie\QueryBuilder\Adapters;
  *
  * @package Pecee\Pixie\QueryBuilder\Adapters
  */
-class Pgsql extends BaseAdapter
-{
-    /**
-     * @var string
-     */
-    const SANITIZER = '"';
+class Pgsql extends BaseAdapter {
+	/**
+	 * @var string
+	 */
+	const SANITIZER = '"';
 }

--- a/src/Pecee/Pixie/QueryBuilder/Adapters/Sqlite.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/Sqlite.php
@@ -7,10 +7,9 @@ namespace Pecee\Pixie\QueryBuilder\Adapters;
  *
  * @package Pecee\Pixie\QueryBuilder\Adapters
  */
-class Sqlite extends BaseAdapter
-{
-    /**
-     * @var string
-     */
-    const SANITIZER = '"';
+class Sqlite extends BaseAdapter {
+	/**
+	 * @var string
+	 */
+	const SANITIZER = '"';
 }

--- a/src/Pecee/Pixie/QueryBuilder/JoinBuilder.php
+++ b/src/Pecee/Pixie/QueryBuilder/JoinBuilder.php
@@ -7,43 +7,42 @@ namespace Pecee\Pixie\QueryBuilder;
  *
  * @package Pecee\Pixie\QueryBuilder
  */
-class JoinBuilder extends QueryBuilderHandler
-{
-    /**
-     * @param string|Raw|\Closure $key
-     * @param string|Raw|\Closure $operator
-     * @param string|Raw|\Closure $value
-     * @return static
-     */
-    public function on($key, $operator, $value)
-    {
-        return $this->joinHandler($key, $operator, $value);
-    }
+class JoinBuilder extends QueryBuilderHandler {
+	/**
+	 * @param string|Raw|\Closure $key
+	 * @param string|Raw|\Closure $operator
+	 * @param string|Raw|\Closure $value
+	 *
+	 * @return static
+	 */
+	public function on($key, $operator, $value) {
+		return $this->joinHandler($key, $operator, $value);
+	}
 
-    /**
-     * @param string|Raw|\Closure $key
-     * @param string|Raw|\Closure $operator
-     * @param string|Raw|\Closure $value
-     * @return static
-     */
-    public function orOn($key, $operator, $value)
-    {
-        return $this->joinHandler($key, $operator, $value, 'OR');
-    }
+	/**
+	 * @param string|Raw|\Closure $key
+	 * @param string|Raw|\Closure $operator
+	 * @param string|Raw|\Closure $value
+	 *
+	 * @return static
+	 */
+	public function orOn($key, $operator, $value) {
+		return $this->joinHandler($key, $operator, $value, 'OR');
+	}
 
-    /**
-     * @param string|Raw|\Closure $key
-     * @param string|Raw|\Closure|null $operator
-     * @param string|Raw|\Closure|null $value
-     * @param string $joiner
-     * @return static
-     */
-    protected function joinHandler($key, $operator = null, $value = null, $joiner = 'AND')
-    {
-        $key = $this->addTablePrefix($key);
-        $value = $this->addTablePrefix($value);
-        $this->statements['criteria'][] = compact('key', 'operator', 'value', 'joiner');
+	/**
+	 * @param string|Raw|\Closure $key
+	 * @param string|Raw|\Closure|null $operator
+	 * @param string|Raw|\Closure|null $value
+	 * @param string $joiner
+	 *
+	 * @return static
+	 */
+	protected function joinHandler($key, $operator = null, $value = null, $joiner = 'AND') {
+		$key                            = $this->addTablePrefix($key);
+		$value                          = $this->addTablePrefix($value);
+		$this->statements['criteria'][] = compact('key', 'operator', 'value', 'joiner');
 
-        return $this;
-    }
+		return $this;
+	}
 }

--- a/src/Pecee/Pixie/QueryBuilder/NestedCriteria.php
+++ b/src/Pecee/Pixie/QueryBuilder/NestedCriteria.php
@@ -7,20 +7,19 @@ namespace Pecee\Pixie\QueryBuilder;
  *
  * @package Pecee\Pixie\QueryBuilder
  */
-class NestedCriteria extends QueryBuilderHandler
-{
-    /**
-     * @param string|Raw|\Closure $key
-     * @param string|Raw|\Closure|null $operator
-     * @param string|Raw|\Closure|null $value
-     * @param string $joiner
-     * @return static
-     */
-    protected function whereHandler($key, $operator = null, $value = null, $joiner = 'AND')
-    {
-        $key = $this->addTablePrefix($key);
-        $this->statements['criteria'][] = compact('key', 'operator', 'value', 'joiner');
+class NestedCriteria extends QueryBuilderHandler {
+	/**
+	 * @param string|Raw|\Closure $key
+	 * @param string|Raw|\Closure|null $operator
+	 * @param string|Raw|\Closure|null $value
+	 * @param string $joiner
+	 *
+	 * @return static
+	 */
+	protected function whereHandler($key, $operator = null, $value = null, $joiner = 'AND') {
+		$key                            = $this->addTablePrefix($key);
+		$this->statements['criteria'][] = compact('key', 'operator', 'value', 'joiner');
 
-        return $this;
-    }
+		return $this;
+	}
 }

--- a/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -15,9 +15,60 @@ class QueryBuilderHandler
 {
 
     /**
-     * @var \Viocon\Container
+     * Event name
+     *
+     * @var string
      */
-    protected $container;
+    const EVENT_BEFORE_DELETE = 'before-delete';
+
+    /**
+     * Event name
+     *
+     * @var string
+     */
+    const EVENT_BEFORE_INSERT = 'before-insert';
+
+    /**
+     * Event name
+     *
+     * @var string
+     */
+    const EVENT_BEFORE_UPDATE = 'before-update';
+
+    /**
+     * Event name
+     *
+     * @var string
+     */
+    const EVENT_BEFORE_SELECT = 'before-select';
+
+    /**
+     * Event name
+     *
+     * @var string
+     */
+    const EVENT_AFTER_DELETE = 'after-delete';
+
+    /**
+     * Event name
+     *
+     * @var string
+     */
+    const EVENT_AFTER_INSERT = 'after-insert';
+
+    /**
+     * Event name
+     *
+     * @var string
+     */
+    const EVENT_AFTER_UPDATE = 'after-update';
+
+    /**
+     * Event name
+     *
+     * @var string
+     */
+    const EVENT_AFTER_SELECT = 'after-select';
 
     /**
      * @var Connection
@@ -79,7 +130,6 @@ class QueryBuilderHandler
         }
 
         $this->connection = $connection;
-        $this->container = $this->connection->getContainer();
         $this->pdo = $this->connection->getPdoInstance();
         $this->adapter = $this->connection->getAdapter();
         $this->adapterConfig = $this->connection->getAdapterConfig();
@@ -89,82 +139,13 @@ class QueryBuilderHandler
         }
 
         // Query builder adapter instance
-        $this->adapterInstance = $this->container->build(
-            '\Pecee\Pixie\QueryBuilder\Adapters\\' . ucfirst($this->adapter),
-            [$this->connection]
-        );
+        $adapterClass = $this->adapter->getQueryAdapterClass();
+        $this->adapterInstance = new $adapterClass($this->connection);
 
         $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-    }
 
-    /**
-     * Add fetch parameters to the PDO-query.
-     *
-     * @param mixed $parameters ...
-     * @return static
-     */
-    public function setFetchMode($parameters = null)
-    {
-        $this->fetchParameters = func_get_args();
-
-        return $this;
-    }
-
-    /**
-     * Fetch query results as object of specified type
-     *
-     * @param string $className
-     * @param array $constructorArgs
-     * @return QueryBuilderHandler
-     */
-    public function asObject($className, array $constructorArgs = [])
-    {
-        return $this->setFetchMode(\PDO::FETCH_CLASS, $className, $constructorArgs);
-    }
-
-    /**
-     * Creates and returns new query.
-     *
-     * @param \Pecee\Pixie\Connection|null $connection
-     * @throws \Pecee\Pixie\Exception
-     * @return static
-     */
-    public function newQuery(Connection $connection = null)
-    {
-        if ($connection === null) {
-            $connection = $this->connection;
-        }
-
-        return new static($connection);
-    }
-
-    /**
-     * Performs query.
-     *
-     * @param string $sql
-     * @param array $bindings
-     * @return static
-     */
-    public function query($sql, array $bindings = [])
-    {
-        list($this->pdoStatement) = $this->statement($sql, $bindings);
-
-        return $this;
-    }
-
-    /**
-     * Add or change table alias
-     * Example: table AS alias
-     *
-     * @param string $table
-     * @param string $alias
-     * @return QueryBuilderHandler
-     */
-    public function alias($table, $alias)
-    {
-        $this->statements['aliases'][$this->tablePrefix . $table] = strtolower($alias);
-
-        return $this;
+        // PDO will parse parameter datatypes automatically
+        $this->pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
     }
 
     /**
@@ -184,934 +165,18 @@ class QueryBuilderHandler
     }
 
     /**
-     * Execute statement
+     * Add new statement to statement-list
      *
-     * @param string $sql
-     * @param array $bindings
-     * @return array PDOStatement and execution time as float
+     * @param string $key
+     * @param mixed $value
      */
-    public function statement($sql, array $bindings = [])
+    protected function addStatement($key, $value)
     {
-        $start = microtime(true);
-
-        $pdoStatement = $this->pdo->prepare($sql);
-
-        /**
-         * NOTE:
-         * PHP 5.6 & 7 bug: https://bugs.php.net/bug.php?id=38546
-         * \PDO::PARAM_BOOL is not supported, use \PDO::PARAM_INT instead
-         */
-
-        foreach ($bindings as $key => $value) {
-            $pdoStatement->bindValue(
-                is_int($key) ? $key + 1 : $key,
-                $value,
-                ((is_int($value) === true || is_bool($value) === true) ? PDO::PARAM_INT : PDO::PARAM_STR)
-            );
-        }
-
-        $pdoStatement->execute();
-
-        return [
-            $pdoStatement,
-            microtime(true) - $start,
-        ];
-    }
-
-    /**
-     * Get all rows
-     *
-     * @throws Exception
-     * @return \stdClass[]
-     */
-    public function get()
-    {
-        $queryObject = null;
-        $executionTime = 0;
-
-        if ($this->pdoStatement === null) {
-            $queryObject = $this->getQuery();
-            list($this->pdoStatement, $executionTime) = $this->statement(
-                $queryObject->getSql(),
-                $queryObject->getBindings()
-            );
-        }
-
-        $start = microtime(true);
-        $this->fireEvents('before-select', $queryObject);
-        $result = call_user_func_array([$this->pdoStatement, 'fetchAll'], $this->fetchParameters);
-        $executionTime += microtime(true) - $start;
-        $this->pdoStatement = null;
-        $this->fireEvents('after-select', $queryObject, $result, $executionTime);
-
-        return $result;
-    }
-
-    /**
-     * Returns the first row
-     *
-     * @throws Exception
-     * @return \stdClass|null
-     */
-    public function first()
-    {
-        $result = $this->limit(1)->get();
-
-        return ($result !== null && count($result) > 0) ? $result[0] : null;
-    }
-
-    /**
-     * Find all by field name and value
-     *
-     * @param string $fieldName
-     * @param string|int|float $value
-     * @throws Exception
-     * @return \stdClass[]
-     */
-    public function findAll($fieldName, $value)
-    {
-        return $this->where($fieldName, '=', $value)->get();
-    }
-
-    /**
-     * Find by value and field name.
-     *
-     * @param string|int|float $value
-     * @param string $fieldName
-     * @throws Exception
-     * @return null|\stdClass
-     */
-    public function find($value, $fieldName = 'id')
-    {
-        return $this->where($fieldName, '=', $value)->first();
-    }
-
-    /**
-     * Get count of rows
-     *
-     * @throws Exception
-     * @return int
-     */
-    public function count()
-    {
-        // Get the current statements
-        $originalStatements = $this->statements;
-
-        unset($this->statements['orderBys'], $this->statements['limit'], $this->statements['offset']);
-
-        $count = $this->aggregate('count');
-        $this->statements = $originalStatements;
-
-        return $count;
-    }
-
-    /**
-     * Performs special queries like COUNT, SUM etc based on the current query.
-     *
-     * @param string $type
-     * @throws Exception
-     * @return int
-     */
-    protected function aggregate($type)
-    {
-        // Get the current selects
-        $mainSelects = isset($this->statements['selects']) ? $this->statements['selects'] : null;
-
-        // Replace select with a scalar value like `count`
-        $this->statements['selects'] = [$this->raw($type . '(*) AS `field`')];
-        $row = $this->get();
-
-        // Set the select as it was
-        if ($mainSelects !== null) {
-            $this->statements['selects'] = $mainSelects;
+        if (array_key_exists($key, $this->statements) === false) {
+            $this->statements[$key] = (array)$value;
         } else {
-            unset($this->statements['selects']);
+            $this->statements[$key] = array_merge($this->statements[$key], (array)$value);
         }
-
-        if (isset($row[0]) === true) {
-            if (is_array($row[0]) === true) {
-                return (int)$row[0]['field'];
-            }
-            if (is_object($row[0]) === true) {
-                return (int)$row[0]->field;
-            }
-        }
-
-        return 0;
-    }
-
-    /**
-     * Returns Query-object.
-     *
-     * @param string $type
-     * @param array|mixed|null $dataToBePassed
-     * @return QueryObject
-     * @throws Exception
-     */
-    public function getQuery($type = 'select', $dataToBePassed = null)
-    {
-        $allowedTypes = [
-            'select',
-            'insert',
-            'insertignore',
-            'replace',
-            'delete',
-            'update',
-            'criteriaonly',
-        ];
-
-        if (in_array(strtolower($type), $allowedTypes, true) === false) {
-            throw new Exception($type . ' is not a known type.', 2);
-        }
-
-        $queryArr = $this->adapterInstance->$type($this->statements, $dataToBePassed);
-
-        return $this->container->build(
-            QueryObject::class,
-            [$queryArr['sql'], $queryArr['bindings'], $this->pdo]
-        );
-    }
-
-    /**
-     * Performs new sub-query.
-     * Call this method when you want to add a new sub-query in your where etc.
-     *
-     * @param QueryBuilderHandler $queryBuilder
-     * @param string|null $alias
-     * @throws Exception
-     * @return Raw
-     */
-    public function subQuery(QueryBuilderHandler $queryBuilder, $alias = null)
-    {
-        $sql = '(' . $queryBuilder->getQuery()->getRawSql() . ')';
-        if ($alias !== null) {
-            $sql = $sql . ' AS ' . $this->adapterInstance->wrapSanitizer($alias);
-        }
-
-        return $queryBuilder->raw($sql);
-    }
-
-    /**
-     * Performs insert
-     *
-     * @param array $data
-     * @param string $type
-     * @throws Exception
-     * @return array|string
-     */
-    private function doInsert($data, $type)
-    {
-        // If first value is not an array - it's not a batch insert
-        if (is_array(current($data)) === false) {
-            $queryObject = $this->getQuery($type, $data);
-
-            $this->fireEvents('before-insert', $queryObject);
-            list($result, $executionTime) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
-            $return = $result->rowCount() === 1 ? $this->pdo->lastInsertId() : null;
-            $this->fireEvents('after-insert', $queryObject, $return, $executionTime);
-
-            return $return;
-        }
-
-        // Perform batch insert
-
-        $return = [];
-        foreach ($data as $subData) {
-            $queryObject = $this->getQuery($type, $subData);
-
-            $this->fireEvents('before-insert', $queryObject);
-            list($result, $executionTime) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
-            $result = $result->rowCount() === 1 ? $this->pdo->lastInsertId() : null;
-            $this->fireEvents('after-insert', $queryObject, $result, $executionTime);
-
-            $return[] = $result;
-        }
-
-        return $return;
-    }
-
-    /**
-     * Insert key/value array
-     *
-     * @param array $data
-     * @throws Exception
-     * @return array|string
-     */
-    public function insert($data)
-    {
-        return $this->doInsert($data, 'insert');
-    }
-
-    /**
-     * Insert with ignore key/value array
-     *
-     * @param array $data
-     * @throws Exception
-     * @return array|string
-     */
-    public function insertIgnore($data)
-    {
-        return $this->doInsert($data, 'insertignore');
-    }
-
-    /**
-     * Replace key/value array
-     *
-     * @param array $data
-     * @throws Exception
-     * @return array|string
-     */
-    public function replace($data)
-    {
-        return $this->doInsert($data, 'replace');
-    }
-
-    /**
-     * Update key/value array
-     *
-     * @param array $data
-     * @throws Exception
-     * @return \PDOStatement
-     */
-    public function update($data)
-    {
-        /**
-         * @var $response \PDOStatement
-         */
-        $queryObject = $this->getQuery('update', $data);
-
-        $this->fireEvents('before-update', $queryObject);
-
-        list($response, $executionTime) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
-        $this->fireEvents('after-update', $queryObject, $executionTime);
-
-        return $response;
-    }
-
-    /**
-     * Update or insert key/value array
-     *
-     * @param array $data
-     * @return array|\PDOStatement|string
-     * @throws Exception
-     */
-    public function updateOrInsert($data)
-    {
-        if ($this->first() !== null) {
-            return $this->update($data);
-        }
-
-        return $this->insert($data);
-    }
-
-    /**
-     * Add on duplicate key statement.
-     *
-     * @param string $data
-     * @return static
-     */
-    public function onDuplicateKeyUpdate($data)
-    {
-        $this->addStatement('onduplicate', $data);
-
-        return $this;
-    }
-
-    /**
-     * Forms delete on the current query.
-     *
-     * @return \PDOStatement
-     * @throws Exception
-     */
-    public function delete()
-    {
-        /* @var $response \PDOStatement */
-        $queryObject = $this->getQuery('delete');
-
-        $this->fireEvents('before-delete', $queryObject);
-
-        list($response, $executionTime) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
-        $this->fireEvents('after-delete', $queryObject, $executionTime);
-
-        return $response;
-    }
-
-    /**
-     * Sets the table that the query is using
-     *
-     * @param string|array $tables Single table or multiple tables as an array or as multiple parameters
-     * @throws Exception
-     * @return static
-     */
-    public function table($tables)
-    {
-        if (is_array($tables) === false) {
-            // Because a single table is converted to an array anyways, this makes sense.
-            $tables = func_get_args();
-        }
-
-        $instance = new static($this->connection);
-        $tables = $this->addTablePrefix($tables, false);
-        $instance->addStatement('tables', $tables);
-
-        return $instance;
-    }
-
-    /**
-     * Adds FROM statement to the current query.
-     *
-     * @param string|array $tables
-     * @return static
-     */
-    public function from($tables)
-    {
-        if (is_array($tables) === false) {
-            $tables = func_get_args();
-        }
-
-        $tables = $this->addTablePrefix($tables, false);
-        $this->addStatement('tables', $tables);
-
-        return $this;
-    }
-
-    /**
-     * Adds fields to select on the current query (defaults is all).
-     * You can use key/value array to create alias.
-     * Sub-queries and raw-objects are also supported.
-     *
-     * Example: ['field' => 'alias'] will become `field` AS `alias`
-     *
-     * @param string|array $fields,...
-     * @return static
-     */
-    public function select($fields)
-    {
-        if (is_array($fields) === false) {
-            $fields = func_get_args();
-        }
-
-        $fields = $this->addTablePrefix($fields);
-        $this->addStatement('selects', $fields);
-
-        return $this;
-    }
-
-    /**
-     * Performs select distinct on the current query.
-     *
-     * @param string|Raw|\Closure|array $fields
-     * @return static
-     */
-    public function selectDistinct($fields)
-    {
-        $this->select($fields);
-        $this->addStatement('distinct', true);
-
-        return $this;
-    }
-
-    /**
-     * Adds GROUP BY to the current query.
-     *
-     * @param string|Raw|\Closure|array $field
-     * @return static
-     */
-    public function groupBy($field)
-    {
-        if (($field instanceof Raw) === false) {
-            $field = $this->addTablePrefix($field);
-        }
-
-        if (is_array($field) === true) {
-            $this->statements['groupBys'] = array_merge($this->statements['groupBys'], $field);
-        } else {
-            $this->statements['groupBys'][] = $field;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Adds ORDER BY statement to the current query.
-     *
-     * @param string|Raw|\Closure|array $fields
-     * @param string $defaultDirection
-     * @return static
-     */
-    public function orderBy($fields, $defaultDirection = 'ASC')
-    {
-        if (is_array($fields) === false) {
-            $fields = [$fields];
-        }
-
-        foreach ((array)$fields as $key => $value) {
-            $field = $key;
-            $type = $value;
-
-            if (is_int($key) === true) {
-                $field = $value;
-                $type = $defaultDirection;
-            }
-
-            if (($field instanceof Raw) === false) {
-                $field = $this->addTablePrefix($field);
-            }
-
-            $this->statements['orderBys'][] = compact('field', 'type');
-        }
-
-        return $this;
-    }
-
-    /**
-     * Adds LIMIT statement to the current query.
-     *
-     * @param int $limit
-     * @return static
-     */
-    public function limit($limit)
-    {
-        $this->statements['limit'] = $limit;
-
-        return $this;
-    }
-
-    /**
-     * Adds OFFSET statement to the current query.
-     *
-     * @param int $offset
-     * @return static $this
-     */
-    public function offset($offset)
-    {
-        $this->statements['offset'] = $offset;
-
-        return $this;
-    }
-
-    /**
-     * Adds HAVING statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|mixed $operator
-     * @param string|mixed $value
-     * @param string $joiner
-     * @return static
-     */
-    public function having($key, $operator, $value, $joiner = 'AND')
-    {
-        $key = $this->addTablePrefix($key);
-        $this->statements['havings'][] = compact('key', 'operator', 'value', 'joiner');
-
-        return $this;
-    }
-
-    /**
-     * Adds OR HAVING statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|Raw|\Closure $operator
-     * @param mixed|Raw|\Closure|null $value
-     * @return static
-     */
-    public function orHaving($key, $operator, $value)
-    {
-        return $this->having($key, $operator, $value, 'OR');
-    }
-
-    /**
-     * Adds WHERE statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|Raw|\Closure|null $operator
-     * @param mixed|Raw|\Closure|null $value
-     * @return static
-     */
-    public function where($key, $operator = null, $value = null)
-    {
-        // If two params are given then assume operator is =
-        if (func_num_args() === 2) {
-            $value = $operator;
-            $operator = '=';
-        }
-
-        if (is_bool($value) === true) {
-            $value = (int)$value;
-        }
-
-        return $this->whereHandler($key, $operator, $value);
-    }
-
-    /**
-     * Adds OR WHERE statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|null $operator
-     * @param mixed|Raw|\Closure|null $value
-     * @return static
-     */
-    public function orWhere($key, $operator = null, $value = null)
-    {
-        // If two params are given then assume operator is =
-        if (func_num_args() === 2) {
-            $value = $operator;
-            $operator = '=';
-        }
-
-        return $this->whereHandler($key, $operator, $value, 'OR');
-    }
-
-    /**
-     * Adds WHERE NOT statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|array|Raw|\Closure|null $operator
-     * @param mixed|Raw|\Closure|null $value
-     * @return static
-     */
-    public function whereNot($key, $operator = null, $value = null)
-    {
-        // If two params are given then assume operator is =
-        if (func_num_args() === 2) {
-            $value = $operator;
-            $operator = '=';
-        }
-
-        return $this->whereHandler($key, $operator, $value, 'AND NOT');
-    }
-
-    /**
-     * Adds OR WHERE NOT statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|array|Raw|\Closure|null $operator
-     * @param mixed|Raw|\Closure|null $value
-     * @return static
-     */
-    public function orWhereNot($key, $operator = null, $value = null)
-    {
-        // If two params are given then assume operator is =
-        if (func_num_args() === 2) {
-            $value = $operator;
-            $operator = '=';
-        }
-
-        return $this->whereHandler($key, $operator, $value, 'OR NOT');
-    }
-
-    /**
-     * Adds WHERE IN statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param array|Raw|\Closure $values
-     * @return static
-     */
-    public function whereIn($key, $values)
-    {
-        return $this->whereHandler($key, 'IN', $values);
-    }
-
-    /**
-     * Adds OR WHERE NOT IN statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param array|Raw|\Closure $values
-     * @return static
-     */
-    public function whereNotIn($key, $values)
-    {
-        return $this->whereHandler($key, 'NOT IN', $values);
-    }
-
-    /**
-     * Adds OR WHERE IN statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param array|Raw|\Closure $values
-     * @return static
-     */
-    public function orWhereIn($key, $values)
-    {
-        return $this->whereHandler($key, 'IN', $values, 'OR');
-    }
-
-    /**
-     * Adds or WHERE NOT IN statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param array|Raw|\Closure $values
-     * @return static
-     */
-    public function orWhereNotIn($key, $values)
-    {
-        return $this->whereHandler($key, 'NOT IN', $values, 'OR');
-    }
-
-    /**
-     * Adds WHERE BETWEEN statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|integer|float $valueFrom
-     * @param string|integer|float $valueTo
-     * @return static
-     */
-    public function whereBetween($key, $valueFrom, $valueTo)
-    {
-        return $this->whereHandler($key, 'BETWEEN', [$valueFrom, $valueTo]);
-    }
-
-    /**
-     * Adds OR WHERE BETWEEN statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|integer|float $valueFrom
-     * @param string|integer|float $valueTo
-     * @return static
-     */
-    public function orWhereBetween($key, $valueFrom, $valueTo)
-    {
-        return $this->whereHandler($key, 'BETWEEN', [$valueFrom, $valueTo], 'OR');
-    }
-
-    /**
-     * Adds WHERE NULL statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @return QueryBuilderHandler
-     */
-    public function whereNull($key)
-    {
-        return $this->whereNullHandler($key);
-    }
-
-    /**
-     * Adds WHERE NOT NULL statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @return QueryBuilderHandler
-     */
-    public function whereNotNull($key)
-    {
-        return $this->whereNullHandler($key, 'NOT');
-    }
-
-    /**
-     * Adds OR WHERE NULL statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @return QueryBuilderHandler
-     */
-    public function orWhereNull($key)
-    {
-        return $this->whereNullHandler($key, '', 'or');
-    }
-
-    /**
-     * Adds OR WHERE NOT NULL statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @return QueryBuilderHandler
-     */
-    public function orWhereNotNull($key)
-    {
-        return $this->whereNullHandler($key, 'NOT', 'or');
-    }
-
-    /**
-     * Handles WHERE NULL statements.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string $prefix
-     * @param string $operator
-     * @return mixed
-     */
-    protected function whereNullHandler($key, $prefix = '', $operator = '')
-    {
-        $key = $this->adapterInstance->wrapSanitizer($this->addTablePrefix($key));
-
-        return $this->{$operator . 'Where'}($this->raw("{$key} IS {$prefix} NULL"));
-    }
-
-    /**
-     * Adds new JOIN statement to the current query.
-     *
-     * @param string|Raw|\Closure $table
-     * @param string|Raw|\Closure $key
-     * @param string|null $operator
-     * @param string|Raw|\Closure $value
-     * @param string $type
-     * @return static
-     */
-    public function join($table, $key, $operator = null, $value = null, $type = 'inner')
-    {
-        if (($key instanceof \Closure) === false) {
-            $key = function (JoinBuilder $joinBuilder) use ($key, $operator, $value) {
-                $joinBuilder->on($key, $operator, $value);
-            };
-        }
-
-        /**
-         * Build a new JoinBuilder class, keep it by reference so any changes made
-         * in the closure should reflect here
-         */
-
-        $joinBuilder = $this->container->build(JoinBuilder::class, [$this->connection]);
-
-        // Call the closure with our new joinBuilder object
-        $key($joinBuilder);
-        $table = $this->addTablePrefix($table, false);
-
-        // Get the criteria only query from the joinBuilder object
-        $this->statements['joins'][] = compact('type', 'table', 'joinBuilder');
-
-        return $this;
-    }
-
-    /**
-     * Performs the transaction
-     *
-     * @param \Closure $callback
-     * @return static
-     */
-    public function transaction(\Closure $callback)
-    {
-        try {
-            // Begin the PDO transaction
-            $this->pdo->beginTransaction();
-
-            // Get the Transaction class
-            $transaction = $this->container->build(Transaction::class, [$this->connection]);
-
-            // Call closure
-            $callback($transaction);
-
-            // If no errors have been thrown or the transaction wasn't completed within the closure, commit the changes
-            $this->pdo->commit();
-
-            return $this;
-        } catch (TransactionHaltException $e) {
-            // Commit or rollback behavior has been handled in the closure, so exit
-            return $this;
-        } catch (\Exception $e) {
-            // something happened, rollback changes
-            $this->pdo->rollBack();
-
-            return $this;
-        }
-    }
-
-    /**
-     * Adds new right join statement to the current query.
-     *
-     * @param string|Raw|\Closure $table
-     * @param string|Raw|\Closure $key
-     * @param string|null $operator
-     * @param string|Raw|\Closure|null $value
-     * @return static
-     */
-    public function rightJoin($table, $key, $operator = null, $value = null)
-    {
-        return $this->join($table, $key, $operator, $value, 'right');
-    }
-
-    /**
-     * Adds new LEFT JOIN statement to the current query.
-     *
-     * @param string|Raw|\Closure $table
-     * @param string|Raw|\Closure $key
-     * @param string|null $operator
-     * @param string|Raw|\Closure|null $value
-     * @return static
-     */
-    public function leftJoin($table, $key, $operator = null, $value = null)
-    {
-        return $this->join($table, $key, $operator, $value, 'left');
-    }
-
-    /**
-     * Adds new INNER JOIN statement to the current query.
-     *
-     * @param string|Raw|\Closure $table
-     * @param string|Raw|\Closure $key
-     * @param string|mixed|null $operator
-     * @param string|Raw|\Closure|null $value
-     * @return static
-     */
-    public function innerJoin($table, $key, $operator = null, $value = null)
-    {
-        return $this->join($table, $key, $operator, $value);
-    }
-
-    /**
-     * Adds a raw string to the current query.
-     * This query will be ignored from any parsing or formatting by the Query builder
-     * and should be used in conjunction with other statements in the query.
-     *
-     * For example: $qb->where('result', '>', $qb->raw('COUNT(`score`)));
-     *
-     * @param string $value
-     * @param array|null|mixed $bindings ...
-     * @return Raw
-     */
-    public function raw($value, $bindings = null)
-    {
-        if (is_array($bindings) === false) {
-            $bindings = func_get_args();
-            array_shift($bindings);
-        }
-
-        return $this->container->build(Raw::class, [$value, $bindings]);
-    }
-
-    /**
-     * Return PDO instance
-     *
-     * @return PDO
-     */
-    public function pdo()
-    {
-        return $this->pdo;
-    }
-
-    /**
-     * Set connection object
-     *
-     * @param Connection $connection
-     * @return static
-     */
-    public function setConnection(Connection $connection)
-    {
-        $this->connection = $connection;
-
-        return $this;
-    }
-
-    /**
-     * Get connection object
-     *
-     * @return Connection
-     */
-    public function getConnection()
-    {
-        return $this->connection;
-    }
-
-    /**
-     * Handles where statements
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|Raw|\Closure|null $operator
-     * @param string|Raw|\Closure|null $value
-     * @param string $joiner
-     * @return static
-     */
-    protected function whereHandler($key, $operator = null, $value = null, $joiner = 'AND')
-    {
-        $key = $this->addTablePrefix($key);
-        $this->statements['wheres'][] = compact('key', 'operator', 'value', 'joiner');
-
-        return $this;
     }
 
     /**
@@ -1166,18 +231,279 @@ class QueryBuilderHandler
     }
 
     /**
-     * Add new statement to statement-list
+     * Performs special queries like COUNT, SUM etc based on the current query.
      *
-     * @param string $key
-     * @param mixed $value
+     * @param string $type
+     * @throws Exception
+     * @return int
      */
-    protected function addStatement($key, $value)
+    protected function aggregate($type)
     {
-        if (array_key_exists($key, $this->statements) === false) {
-            $this->statements[$key] = (array)$value;
+        // Get the current selects
+        $mainSelects = isset($this->statements['selects']) === true ? $this->statements['selects'] : null;
+
+        // Replace select with a scalar value like `count`
+        $this->statements['selects'] = [$this->raw($type . '(*) AS `field`')];
+        $row = $this->get();
+
+        // Set the select as it was
+        if ($mainSelects !== null) {
+            $this->statements['selects'] = $mainSelects;
         } else {
-            $this->statements[$key] = array_merge($this->statements[$key], (array)$value);
+            unset($this->statements['selects']);
         }
+
+        if (isset($row[0]) === true) {
+            if (is_array($row[0]) === true) {
+                return (int)$row[0]['field'];
+            }
+            if (is_object($row[0]) === true) {
+                return (int)$row[0]->field;
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * Add or change table alias
+     * Example: table AS alias
+     *
+     * @param string $alias
+     * @param string $table
+     *
+     * @return QueryBuilderHandler
+     */
+    public function alias($alias, $table = null)
+    {
+        if ($table === null && isset($this->statements['tables'][0]) === true) {
+            $table = $this->statements['tables'][0];
+        } else {
+            $table = $this->tablePrefix . $table;
+        }
+
+        $this->statements['aliases'][$table] = strtolower($alias);
+
+        return $this;
+    }
+
+    /**
+     * Fetch query results as object of specified type
+     *
+     * @param string $className
+     * @param array $constructorArgs
+     * @return QueryBuilderHandler
+     */
+    public function asObject($className, array $constructorArgs = [])
+    {
+        return $this->setFetchMode(\PDO::FETCH_CLASS, $className, $constructorArgs);
+    }
+
+    /**
+     * Get count of rows
+     *
+     * @throws Exception
+     * @return int
+     */
+    public function count()
+    {
+        // Get the current statements
+        $originalStatements = $this->statements;
+
+        unset($this->statements['orderBys'], $this->statements['limit'], $this->statements['offset']);
+
+        $count = $this->aggregate('count');
+        $this->statements = $originalStatements;
+
+        return $count;
+    }
+
+    /**
+     * Forms delete on the current query.
+     *
+     * @return \PDOStatement
+     * @throws Exception
+     */
+    public function delete()
+    {
+        /* @var $response \PDOStatement */
+        $queryObject = $this->getQuery('delete');
+
+        $this->fireEvents(static::EVENT_BEFORE_DELETE, $queryObject);
+
+        list($response, $executionTime) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
+        $this->fireEvents(static::EVENT_AFTER_DELETE, $queryObject, $executionTime);
+
+        return $response;
+    }
+
+    /**
+     * Performs insert
+     *
+     * @param array $data
+     * @param string $type
+     * @throws Exception
+     * @return array|string
+     */
+    private function doInsert($data, $type)
+    {
+        // Insert single item
+
+        if (is_array(current($data)) === false) {
+            $queryObject = $this->getQuery($type, $data);
+
+            $this->fireEvents(static::EVENT_BEFORE_INSERT, $queryObject);
+            /**
+             * @var $result        \PDOStatement
+             * @var $executionTime float
+             */
+            list($result, $executionTime) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
+
+            $insertId = $result->rowCount() === 1 ? $this->pdo->lastInsertId() : null;
+            $this->fireEvents(static::EVENT_AFTER_INSERT, $queryObject, $insertId, $executionTime);
+
+            return $insertId;
+        }
+
+        $insertIds = [];
+
+        // If the current batch insert is not in a transaction, we create one...
+
+        if ($this->pdo->inTransaction() === false) {
+
+            $this->transaction(function (Transaction $transaction) use (&$insertIds, $data, $type) {
+                foreach ($data as $subData) {
+                    $insertIds[] = $transaction->doInsert($subData, $type);
+                }
+            });
+
+            return $insertIds;
+        }
+
+        // Otherwise insert one by one...
+
+        foreach ($data as $subData) {
+            $insertIds[] = $this->doInsert($subData, $type);
+        }
+
+        return $insertIds;
+    }
+
+    /**
+     * Find by value and field name.
+     *
+     * @param string|int|float $value
+     * @param string $fieldName
+     * @throws Exception
+     * @return null|\stdClass
+     */
+    public function find($value, $fieldName = 'id')
+    {
+        return $this->where($fieldName, '=', $value)->first();
+    }
+
+    /**
+     * Find all by field name and value
+     *
+     * @param string $fieldName
+     * @param string|int|float $value
+     * @throws Exception
+     * @return \stdClass[]
+     */
+    public function findAll($fieldName, $value)
+    {
+        return $this->where($fieldName, '=', $value)->get();
+    }
+
+    /**
+     * Fires event by given event name
+     *
+     * @param string $name
+     * @param ... $parameters
+     * @return mixed|null
+     */
+    public function fireEvents($name, $parameters = null)
+    {
+        $params = func_get_args();
+        array_unshift($params, $this);
+
+        return call_user_func_array([$this->connection->getEventHandler(), 'fireEvents'], $params);
+    }
+
+    /**
+     * Returns the first row
+     *
+     * @throws Exception
+     * @return \stdClass|null
+     */
+    public function first()
+    {
+        $result = $this->limit(1)->get();
+
+        return ($result !== null && count($result) > 0) ? $result[0] : null;
+    }
+
+    /**
+     * Adds FROM statement to the current query.
+     *
+     * @param string|array $tables
+     * @return static
+     */
+    public function from($tables)
+    {
+        if (is_array($tables) === false) {
+            $tables = func_get_args();
+        }
+
+        $tables = $this->addTablePrefix($tables, false);
+        $this->addStatement('tables', $tables);
+
+        return $this;
+    }
+
+    /**
+     * Get all rows
+     *
+     * @throws Exception
+     * @return \stdClass[]
+     */
+    public function get()
+    {
+        /**
+         * @var $queryObject   \Pecee\Pixie\QueryBuilder\QueryObject
+         * @var $executionTime float
+         * @var $start         float
+         * @var $result        array
+         */
+        $queryObject = null;
+        $executionTime = 0;
+
+        if ($this->pdoStatement === null) {
+            $queryObject = $this->getQuery();
+            list($this->pdoStatement, $executionTime) = $this->statement(
+                $queryObject->getSql(),
+                $queryObject->getBindings()
+            );
+        }
+
+        $start = microtime(true);
+        $this->fireEvents(static::EVENT_BEFORE_SELECT, $queryObject);
+        $result = call_user_func_array([$this->pdoStatement, 'fetchAll'], $this->fetchParameters);
+        $executionTime += microtime(true) - $start;
+        $this->pdoStatement = null;
+        $this->fireEvents(static::EVENT_AFTER_SELECT, $queryObject, $result, $executionTime);
+
+        return $result;
+    }
+
+    /**
+     * Get connection object
+     *
+     * @return Connection
+     */
+    public function getConnection()
+    {
+        return $this->connection;
     }
 
     /**
@@ -1190,6 +516,413 @@ class QueryBuilderHandler
     public function getEvent($name, $table = null)
     {
         return $this->connection->getEventHandler()->getEvent($name, $table);
+    }
+
+    /**
+     * Returns Query-object.
+     *
+     * @param string $type
+     * @param array|mixed|null $dataToBePassed
+     * @return QueryObject
+     * @throws Exception
+     */
+    public function getQuery($type = 'select', $dataToBePassed = null)
+    {
+        $allowedTypes = [
+            'select',
+            'insert',
+            'insertignore',
+            'replace',
+            'delete',
+            'update',
+            'criteriaonly',
+        ];
+
+        if (in_array(strtolower($type), $allowedTypes, true) === false) {
+            throw new Exception($type . ' is not a known type.', 2);
+        }
+
+        $queryArr = $this->adapterInstance->$type($this->statements, $dataToBePassed);
+
+        return new QueryObject($queryArr['sql'], $queryArr['bindings'], $this->pdo);
+    }
+
+    /**
+     * Returns statements
+     *
+     * @return array
+     */
+    public function getStatements()
+    {
+        return $this->statements;
+    }
+
+    /**
+     * Adds GROUP BY to the current query.
+     *
+     * @param string|Raw|\Closure|array $field
+     * @return static
+     */
+    public function groupBy($field)
+    {
+        if (($field instanceof Raw) === false) {
+            $field = $this->addTablePrefix($field);
+        }
+
+        if (is_array($field) === true) {
+            $this->statements['groupBys'] = array_merge($this->statements['groupBys'], $field);
+        } else {
+            $this->statements['groupBys'][] = $field;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Adds HAVING statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @param string|mixed $operator
+     * @param string|mixed $value
+     * @param string $joiner
+     * @return static
+     */
+    public function having($key, $operator, $value, $joiner = 'AND')
+    {
+        $key = $this->addTablePrefix($key);
+        $this->statements['havings'][] = compact('key', 'operator', 'value', 'joiner');
+
+        return $this;
+    }
+
+    /**
+     * Adds new INNER JOIN statement to the current query.
+     *
+     * @param string|Raw|\Closure $table
+     * @param string|Raw|\Closure $key
+     * @param string|mixed|null $operator
+     * @param string|Raw|\Closure|null $value
+     * @return static
+     */
+    public function innerJoin($table, $key, $operator = null, $value = null)
+    {
+        return $this->join($table, $key, $operator, $value);
+    }
+
+    /**
+     * Insert key/value array
+     *
+     * @param array $data
+     * @throws Exception
+     * @return array|string
+     */
+    public function insert($data)
+    {
+        return $this->doInsert($data, 'insert');
+    }
+
+    /**
+     * Insert with ignore key/value array
+     *
+     * @param array $data
+     * @throws Exception
+     * @return array|string
+     */
+    public function insertIgnore($data)
+    {
+        return $this->doInsert($data, 'insertignore');
+    }
+
+    /**
+     * Adds new JOIN statement to the current query.
+     *
+     * @param string|Raw|\Closure $table
+     * @param string|Raw|\Closure $key
+     * @param string|null $operator
+     * @param string|Raw|\Closure $value
+     * @param string $type
+     * @throws Exception
+     * @return static
+     */
+    public function join($table, $key, $operator = null, $value = null, $type = 'inner')
+    {
+        if (($key instanceof \Closure) === false) {
+            $key = function (JoinBuilder $joinBuilder) use ($key, $operator, $value) {
+                $joinBuilder->on($key, $operator, $value);
+            };
+        }
+
+        /**
+         * Build a new JoinBuilder class, keep it by reference so any changes made
+         * in the closure should reflect here
+         */
+
+        $joinBuilder = new JoinBuilder($this->connection);
+
+        // Call the closure with our new joinBuilder object
+        $key($joinBuilder);
+        $table = $this->addTablePrefix($table, false);
+
+        // Get the criteria only query from the joinBuilder object
+        $this->statements['joins'][] = compact('type', 'table', 'joinBuilder');
+
+        return $this;
+    }
+
+    /**
+     * Adds new LEFT JOIN statement to the current query.
+     *
+     * @param string|Raw|\Closure $table
+     * @param string|Raw|\Closure $key
+     * @param string|null $operator
+     * @param string|Raw|\Closure|null $value
+     * @return static
+     */
+    public function leftJoin($table, $key, $operator = null, $value = null)
+    {
+        return $this->join($table, $key, $operator, $value, 'left');
+    }
+
+    /**
+     * Adds LIMIT statement to the current query.
+     *
+     * @param int $limit
+     * @return static
+     */
+    public function limit($limit)
+    {
+        $this->statements['limit'] = $limit;
+
+        return $this;
+    }
+
+    /**
+     * Creates and returns new query.
+     *
+     * @param \Pecee\Pixie\Connection|null $connection
+     * @throws \Pecee\Pixie\Exception
+     * @return static
+     */
+    public function newQuery(Connection $connection = null)
+    {
+        if ($connection === null) {
+            $connection = $this->connection;
+        }
+
+        return new static($connection);
+    }
+
+    /**
+     * Adds OFFSET statement to the current query.
+     *
+     * @param int $offset
+     * @return static $this
+     */
+    public function offset($offset)
+    {
+        $this->statements['offset'] = $offset;
+
+        return $this;
+    }
+
+    /**
+     * Add on duplicate key statement.
+     *
+     * @param string $data
+     * @return static
+     */
+    public function onDuplicateKeyUpdate($data)
+    {
+        $this->addStatement('onduplicate', $data);
+
+        return $this;
+    }
+
+    /**
+     * Adds OR HAVING statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @param string|Raw|\Closure $operator
+     * @param mixed|Raw|\Closure|null $value
+     * @return static
+     */
+    public function orHaving($key, $operator, $value)
+    {
+        return $this->having($key, $operator, $value, 'OR');
+    }
+
+    /**
+     * Adds OR WHERE statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @param string|null $operator
+     * @param mixed|Raw|\Closure|null $value
+     * @return static
+     */
+    public function orWhere($key, $operator = null, $value = null)
+    {
+        // If two params are given then assume operator is =
+        if (func_num_args() === 2) {
+            $value = $operator;
+            $operator = '=';
+        }
+
+        return $this->whereHandler($key, $operator, $value, 'OR');
+    }
+
+    /**
+     * Adds OR WHERE BETWEEN statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @param string|integer|float $valueFrom
+     * @param string|integer|float $valueTo
+     * @return static
+     */
+    public function orWhereBetween($key, $valueFrom, $valueTo)
+    {
+        return $this->whereHandler($key, 'BETWEEN', [$valueFrom, $valueTo], 'OR');
+    }
+
+    /**
+     * Adds OR WHERE IN statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @param array|Raw|\Closure $values
+     * @return static
+     */
+    public function orWhereIn($key, $values)
+    {
+        return $this->whereHandler($key, 'IN', $values, 'OR');
+    }
+
+    /**
+     * Adds OR WHERE NOT statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @param string|array|Raw|\Closure|null $operator
+     * @param mixed|Raw|\Closure|null $value
+     * @return static
+     */
+    public function orWhereNot($key, $operator = null, $value = null)
+    {
+        // If two params are given then assume operator is =
+        if (func_num_args() === 2) {
+            $value = $operator;
+            $operator = '=';
+        }
+
+        return $this->whereHandler($key, $operator, $value, 'OR NOT');
+    }
+
+    /**
+     * Adds or WHERE NOT IN statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @param array|Raw|\Closure $values
+     * @return static
+     */
+    public function orWhereNotIn($key, $values)
+    {
+        return $this->whereHandler($key, 'NOT IN', $values, 'OR');
+    }
+
+    /**
+     * Adds OR WHERE NOT NULL statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @return QueryBuilderHandler
+     */
+    public function orWhereNotNull($key)
+    {
+        return $this->whereNullHandler($key, 'NOT', 'or');
+    }
+
+    /**
+     * Adds OR WHERE NULL statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @return QueryBuilderHandler
+     */
+    public function orWhereNull($key)
+    {
+        return $this->whereNullHandler($key, '', 'or');
+    }
+
+    /**
+     * Adds ORDER BY statement to the current query.
+     *
+     * @param string|Raw|\Closure|array $fields
+     * @param string $defaultDirection
+     * @return static
+     */
+    public function orderBy($fields, $defaultDirection = 'ASC')
+    {
+        if (is_array($fields) === false) {
+            $fields = [$fields];
+        }
+
+        foreach ((array)$fields as $key => $value) {
+            $field = $key;
+            $type = $value;
+
+            if (is_int($key) === true) {
+                $field = $value;
+                $type = $defaultDirection;
+            }
+
+            if (($field instanceof Raw) === false) {
+                $field = $this->addTablePrefix($field);
+            }
+
+            $this->statements['orderBys'][] = compact('field', 'type');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Return PDO instance
+     *
+     * @return PDO
+     */
+    public function pdo()
+    {
+        return $this->pdo;
+    }
+
+    /**
+     * Performs query.
+     *
+     * @param string $sql
+     * @param array $bindings
+     * @return static
+     */
+    public function query($sql, array $bindings = [])
+    {
+        list($this->pdoStatement) = $this->statement($sql, $bindings);
+
+        return $this;
+    }
+
+    /**
+     * Adds a raw string to the current query.
+     * This query will be ignored from any parsing or formatting by the Query builder
+     * and should be used in conjunction with other statements in the query.
+     *
+     * For example: $qb->where('result', '>', $qb->raw('COUNT(`score`)));
+     *
+     * @param string $value
+     * @param array|null|mixed $bindings ...
+     * @return Raw
+     */
+    public function raw($value, $bindings = null)
+    {
+        if (is_array($bindings) === false) {
+            $bindings = func_get_args();
+            array_shift($bindings);
+        }
+
+        return new Raw($value, $bindings);
     }
 
     /**
@@ -1218,27 +951,381 @@ class QueryBuilderHandler
     }
 
     /**
-     * Fires event by given event name
+     * Replace key/value array
      *
-     * @param string $name
-     * @param ... $parameters
-     * @return mixed|null
+     * @param array $data
+     * @throws Exception
+     * @return array|string
      */
-    public function fireEvents($name, $parameters = null)
+    public function replace($data)
     {
-        $params = func_get_args();
-        array_unshift($params, $this);
-
-        return call_user_func_array([$this->connection->getEventHandler(), 'fireEvents'], $params);
+        return $this->doInsert($data, 'replace');
     }
 
     /**
-     * Returns statements
+     * Adds new right join statement to the current query.
      *
-     * @return array
+     * @param string|Raw|\Closure $table
+     * @param string|Raw|\Closure $key
+     * @param string|null $operator
+     * @param string|Raw|\Closure|null $value
+     * @return static
      */
-    public function getStatements()
+    public function rightJoin($table, $key, $operator = null, $value = null)
     {
-        return $this->statements;
+        return $this->join($table, $key, $operator, $value, 'right');
     }
+
+    /**
+     * Adds fields to select on the current query (defaults is all).
+     * You can use key/value array to create alias.
+     * Sub-queries and raw-objects are also supported.
+     *
+     * Example: ['field' => 'alias'] will become `field` AS `alias`
+     *
+     * @param string|array $fields,...
+     * @return static
+     */
+    public function select($fields)
+    {
+        if (is_array($fields) === false) {
+            $fields = func_get_args();
+        }
+
+        $fields = $this->addTablePrefix($fields);
+        $this->addStatement('selects', $fields);
+
+        return $this;
+    }
+
+    /**
+     * Performs select distinct on the current query.
+     *
+     * @param string|Raw|\Closure|array $fields
+     * @return static
+     */
+    public function selectDistinct($fields)
+    {
+        $this->select($fields);
+        $this->addStatement('distinct', true);
+
+        return $this;
+    }
+
+    /**
+     * Set connection object
+     *
+     * @param Connection $connection
+     * @return static
+     */
+    public function setConnection(Connection $connection)
+    {
+        $this->connection = $connection;
+
+        return $this;
+    }
+
+    /**
+     * Add fetch parameters to the PDO-query.
+     *
+     * @param mixed $parameters ...
+     * @return static
+     */
+    public function setFetchMode($parameters = null)
+    {
+        $this->fetchParameters = func_get_args();
+
+        return $this;
+    }
+
+    /**
+     * Execute statement
+     *
+     * @param string $sql
+     * @param array $bindings
+     * @return array PDOStatement and execution time as float
+     */
+    public function statement($sql, array $bindings = [])
+    {
+        $start = microtime(true);
+
+        $pdoStatement = $this->pdo->prepare($sql);
+
+        $pdoStatement->execute($bindings);
+
+        return [$pdoStatement, microtime(true) - $start];
+    }
+
+    /**
+     * Performs new sub-query.
+     * Call this method when you want to add a new sub-query in your where etc.
+     *
+     * @param QueryBuilderHandler $queryBuilder
+     * @param string|null $alias
+     * @throws Exception
+     * @return Raw
+     */
+    public function subQuery(QueryBuilderHandler $queryBuilder, $alias = null)
+    {
+        $sql = '(' . $queryBuilder->getQuery()->getRawSql() . ')';
+        if ($alias !== null) {
+            $sql = $sql . ' AS ' . $this->adapterInstance->wrapSanitizer($alias);
+        }
+
+        return $queryBuilder->raw($sql);
+    }
+
+    /**
+     * Sets the table that the query is using
+     *
+     * @param string|array $tables Single table or multiple tables as an array or as multiple parameters
+     * @throws Exception
+     * @return static
+     */
+    public function table($tables)
+    {
+        $tTables = [];
+
+        if (is_array($tables) === false) {
+            // Because a single table is converted to an array anyways, this makes sense.
+            $tables = \func_get_args();
+        }
+
+        $instance = new static($this->connection);
+
+        foreach ($tables as $key => $value) {
+            if (is_string($key)) {
+                $instance->alias($value, $key);
+                $tTables[] = $key;
+            } else {
+                $tTables[] = $value;
+            }
+        }
+
+        $tTables = $this->addTablePrefix($tTables, false);
+        $instance->addStatement('tables', $tTables);
+
+        return $instance;
+    }
+
+    /**
+     * Performs the transaction
+     *
+     * @param \Closure $callback
+     * @return static
+     * @throws Exception
+     */
+    public function transaction(\Closure $callback)
+    {
+        /**
+         * Get the Transaction class
+         *
+         * @var \Pecee\Pixie\QueryBuilder\Transaction $queryTransaction
+         * @throws \Exception
+         */
+        $queryTransaction = new Transaction($this->connection);
+        $queryTransaction->statements = $this->statements;
+
+        try {
+            // Begin the PDO transaction
+            if($this->pdo->inTransaction() === false) {
+                $this->pdo->beginTransaction();
+            }
+
+            // Call closure - this callback will return TransactionHaltException if user has already committed the transaction
+            $callback($queryTransaction);
+
+            // If no errors have been thrown or the transaction wasn't completed within the closure, commit the changes
+            $this->pdo->commit();
+
+        } catch (TransactionHaltException $e) {
+
+            // Commit or rollback behavior has been triggered in the closure
+            return $this;
+
+        } catch (\Exception $e) {
+
+            // Something went wrong. Rollback and throw Exception
+            if($this->pdo->inTransaction() === true) {
+                $this->pdo->rollBack();
+            }
+
+            throw new Exception($e->getMessage());
+        }
+
+        return $queryTransaction;
+    }
+
+    /**
+     * Update key/value array
+     *
+     * @param array $data
+     * @throws Exception
+     * @return \PDOStatement
+     */
+    public function update($data)
+    {
+        /**
+         * @var $response \PDOStatement
+         */
+        $queryObject = $this->getQuery('update', $data);
+
+        $this->fireEvents(static::EVENT_BEFORE_UPDATE, $queryObject);
+
+        list($response, $executionTime) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
+        $this->fireEvents(static::EVENT_AFTER_UPDATE, $queryObject, $executionTime);
+
+        return $response;
+    }
+
+    /**
+     * Update or insert key/value array
+     *
+     * @param array $data
+     * @return array|\PDOStatement|string
+     * @throws Exception
+     */
+    public function updateOrInsert($data)
+    {
+        if ($this->first() !== null) {
+            return $this->update($data);
+        }
+
+        return $this->insert($data);
+    }
+
+    /**
+     * Adds WHERE statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @param string|Raw|\Closure|null $operator
+     * @param mixed|Raw|\Closure|null $value
+     * @return static
+     */
+    public function where($key, $operator = null, $value = null)
+    {
+        // If two params are given then assume operator is =
+        if (func_num_args() === 2) {
+            $value = $operator;
+            $operator = '=';
+        }
+
+        if (is_bool($value) === true) {
+            $value = (int)$value;
+        }
+
+        return $this->whereHandler($key, $operator, $value);
+    }
+
+    /**
+     * Adds WHERE BETWEEN statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @param string|integer|float $valueFrom
+     * @param string|integer|float $valueTo
+     * @return static
+     */
+    public function whereBetween($key, $valueFrom, $valueTo)
+    {
+        return $this->whereHandler($key, 'BETWEEN', [$valueFrom, $valueTo]);
+    }
+
+    /**
+     * Handles where statements
+     *
+     * @param string|Raw|\Closure $key
+     * @param string|Raw|\Closure|null $operator
+     * @param string|Raw|\Closure|null $value
+     * @param string $joiner
+     * @return static
+     */
+    protected function whereHandler($key, $operator = null, $value = null, $joiner = 'AND')
+    {
+        $key = $this->addTablePrefix($key);
+        $this->statements['wheres'][] = compact('key', 'operator', 'value', 'joiner');
+
+        return $this;
+    }
+
+    /**
+     * Adds WHERE IN statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @param array|Raw|\Closure $values
+     * @return static
+     */
+    public function whereIn($key, $values)
+    {
+        return $this->whereHandler($key, 'IN', $values);
+    }
+
+    /**
+     * Adds WHERE NOT statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @param string|array|Raw|\Closure|null $operator
+     * @param mixed|Raw|\Closure|null $value
+     * @return static
+     */
+    public function whereNot($key, $operator = null, $value = null)
+    {
+        // If two params are given then assume operator is =
+        if (func_num_args() === 2) {
+            $value = $operator;
+            $operator = '=';
+        }
+
+        return $this->whereHandler($key, $operator, $value, 'AND NOT');
+    }
+
+    /**
+     * Adds OR WHERE NOT IN statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @param array|Raw|\Closure $values
+     * @return static
+     */
+    public function whereNotIn($key, $values)
+    {
+        return $this->whereHandler($key, 'NOT IN', $values);
+    }
+
+    /**
+     * Adds WHERE NOT NULL statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @return QueryBuilderHandler
+     */
+    public function whereNotNull($key)
+    {
+        return $this->whereNullHandler($key, 'NOT');
+    }
+
+    /**
+     * Adds WHERE NULL statement to the current query.
+     *
+     * @param string|Raw|\Closure $key
+     * @return QueryBuilderHandler
+     */
+    public function whereNull($key)
+    {
+        return $this->whereNullHandler($key);
+    }
+
+    /**
+     * Handles WHERE NULL statements.
+     *
+     * @param string|Raw|\Closure $key
+     * @param string $prefix
+     * @param string $operator
+     * @return mixed
+     */
+    protected function whereNullHandler($key, $prefix = '', $operator = '')
+    {
+        $key = $this->adapterInstance->wrapSanitizer($this->addTablePrefix($key));
+        $prefix = ($prefix !== '') ? $prefix . ' ' : $prefix;
+
+        return $this->{$operator . 'Where'}($this->raw("$key IS {$prefix}NULL"));
+    }
+
 }

--- a/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -4,6 +4,7 @@ namespace Pecee\Pixie\QueryBuilder;
 
 use PDO;
 use Pecee\Pixie\Connection;
+use Pecee\Pixie\EventHandler;
 use Pecee\Pixie\Exception;
 
 /**
@@ -11,1321 +12,1270 @@ use Pecee\Pixie\Exception;
  *
  * @package Pecee\Pixie\QueryBuilder
  */
-class QueryBuilderHandler
-{
-
-    /**
-     * Event name
-     *
-     * @var string
-     */
-    const EVENT_BEFORE_DELETE = 'before-delete';
-
-    /**
-     * Event name
-     *
-     * @var string
-     */
-    const EVENT_BEFORE_INSERT = 'before-insert';
-
-    /**
-     * Event name
-     *
-     * @var string
-     */
-    const EVENT_BEFORE_UPDATE = 'before-update';
-
-    /**
-     * Event name
-     *
-     * @var string
-     */
-    const EVENT_BEFORE_SELECT = 'before-select';
-
-    /**
-     * Event name
-     *
-     * @var string
-     */
-    const EVENT_AFTER_DELETE = 'after-delete';
-
-    /**
-     * Event name
-     *
-     * @var string
-     */
-    const EVENT_AFTER_INSERT = 'after-insert';
-
-    /**
-     * Event name
-     *
-     * @var string
-     */
-    const EVENT_AFTER_UPDATE = 'after-update';
-
-    /**
-     * Event name
-     *
-     * @var string
-     */
-    const EVENT_AFTER_SELECT = 'after-select';
-
-    /**
-     * @var Connection
-     */
-    protected $connection;
-
-    /**
-     * @var array
-     */
-    protected $statements = [
-        'groupBys' => [],
-    ];
-
-    /**
-     * @var \PDO
-     */
-    protected $pdo;
-
-    /**
-     * @var null|\PDOStatement
-     */
-    protected $pdoStatement;
-
-    /**
-     * @var null|string
-     */
-    protected $tablePrefix;
-
-    /**
-     * @var \Pecee\Pixie\QueryBuilder\Adapters\BaseAdapter
-     */
-    protected $adapterInstance;
-
-    /**
-     * The PDO fetch parameters to use
-     *
-     * @var array
-     */
-    protected $fetchParameters = [\PDO::FETCH_OBJ];
-
-    /**
-     * @var string
-     */
-    protected $adapter;
-
-    /**
-     * @var array
-     */
-    protected $adapterConfig;
-
-    /**
-     * @param \Pecee\Pixie\Connection|null $connection
-     * @throws \Pecee\Pixie\Exception
-     */
-    public function __construct(Connection $connection = null)
-    {
-        if ($connection === null && ($connection = Connection::getStoredConnection()) === false) {
-            throw new Exception('No database connection found.', 1);
-        }
-
-        $this->connection = $connection;
-        $this->pdo = $this->connection->getPdoInstance();
-        $this->adapter = $this->connection->getAdapter();
-        $this->adapterConfig = $this->connection->getAdapterConfig();
-
-        if (isset($this->adapterConfig['prefix']) === true) {
-            $this->tablePrefix = $this->adapterConfig['prefix'];
-        }
-
-        // Query builder adapter instance
-        $adapterClass = $this->adapter->getQueryAdapterClass();
-        $this->adapterInstance = new $adapterClass($this->connection);
-
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-
-        // PDO will parse parameter datatypes automatically
-        $this->pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
-    }
-
-    /**
-     * Add or change table alias
-     *
-     * Example: table AS alias
-     *
-     * @deprecated This method will be removed in the near future, please use QueryBuilderHandler::alias instead.
-     * @see QueryBuilderHandler::alias
-     * @param string $table
-     * @param string $alias
-     * @return QueryBuilderHandler
-     */
-    public function prefix($table, $alias)
-    {
-        return $this->alias($table, $alias);
-    }
-
-    /**
-     * Add new statement to statement-list
-     *
-     * @param string $key
-     * @param mixed $value
-     */
-    protected function addStatement($key, $value)
-    {
-        if (array_key_exists($key, $this->statements) === false) {
-            $this->statements[$key] = (array)$value;
-        } else {
-            $this->statements[$key] = array_merge($this->statements[$key], (array)$value);
-        }
-    }
-
-    /**
-     * Add table prefix (if given) on given string.
-     *
-     * @param string|array|Raw|\Closure $values
-     * @param bool $tableFieldMix If we have mixes of field and table names with a "."
-     * @return array|string
-     */
-    public function addTablePrefix($values, $tableFieldMix = true)
-    {
-        if ($this->tablePrefix === null) {
-            return $values;
-        }
-
-        // $value will be an array and we will add prefix to all table names
-        // If supplied value is not an array then make it one
-
-        $single = false;
-        if (is_array($values) === false) {
-            $values = [$values];
-
-            // We had single value, so should return a single value
-            $single = true;
-        }
-
-        $return = [];
-
-        foreach ($values as $key => $value) {
-            // It's a raw query, just add it to our return array and continue next
-            if ($value instanceof Raw || $value instanceof \Closure) {
-                $return[$key] = $value;
-                continue;
-            }
-
-            // If key is not integer, it is likely a alias mapping, so we need to change prefix target
-            $target = &$value;
-
-            if (is_int($key) === false) {
-                $target = &$key;
-            }
-
-            if ($tableFieldMix === false || ($tableFieldMix && strpos($target, '.') !== false)) {
-                $target = $this->tablePrefix . $target;
-            }
-
-            $return[$key] = $value;
-        }
-
-        // If we had single value then we should return a single value (end value of the array)
-        return $single ? end($return) : $return;
-    }
-
-    /**
-     * Performs special queries like COUNT, SUM etc based on the current query.
-     *
-     * @param string $type
-     * @throws Exception
-     * @return int
-     */
-    protected function aggregate($type)
-    {
-        // Get the current selects
-        $mainSelects = isset($this->statements['selects']) === true ? $this->statements['selects'] : null;
-
-        // Replace select with a scalar value like `count`
-        $this->statements['selects'] = [$this->raw($type . '(*) AS `field`')];
-        $row = $this->get();
-
-        // Set the select as it was
-        if ($mainSelects !== null) {
-            $this->statements['selects'] = $mainSelects;
-        } else {
-            unset($this->statements['selects']);
-        }
-
-        if (isset($row[0]) === true) {
-            if (is_array($row[0]) === true) {
-                return (int)$row[0]['field'];
-            }
-            if (is_object($row[0]) === true) {
-                return (int)$row[0]->field;
-            }
-        }
-
-        return 0;
-    }
-
-    /**
-     * Add or change table alias
-     * Example: table AS alias
-     *
-     * @param string $alias
-     * @param string $table
-     *
-     * @return QueryBuilderHandler
-     */
-    public function alias($alias, $table = null)
-    {
-        if ($table === null && isset($this->statements['tables'][0]) === true) {
-            $table = $this->statements['tables'][0];
-        } else {
-            $table = $this->tablePrefix . $table;
-        }
-
-        $this->statements['aliases'][$table] = strtolower($alias);
-
-        return $this;
-    }
-
-    /**
-     * Fetch query results as object of specified type
-     *
-     * @param string $className
-     * @param array $constructorArgs
-     * @return QueryBuilderHandler
-     */
-    public function asObject($className, array $constructorArgs = [])
-    {
-        return $this->setFetchMode(\PDO::FETCH_CLASS, $className, $constructorArgs);
-    }
-
-    /**
-     * Get count of rows
-     *
-     * @throws Exception
-     * @return int
-     */
-    public function count()
-    {
-        // Get the current statements
-        $originalStatements = $this->statements;
-
-        unset($this->statements['orderBys'], $this->statements['limit'], $this->statements['offset']);
-
-        $count = $this->aggregate('count');
-        $this->statements = $originalStatements;
-
-        return $count;
-    }
-
-    /**
-     * Forms delete on the current query.
-     *
-     * @return \PDOStatement
-     * @throws Exception
-     */
-    public function delete()
-    {
-        /* @var $response \PDOStatement */
-        $queryObject = $this->getQuery('delete');
-
-        $this->fireEvents(static::EVENT_BEFORE_DELETE, $queryObject);
-
-        list($response, $executionTime) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
-        $this->fireEvents(static::EVENT_AFTER_DELETE, $queryObject, $executionTime);
-
-        return $response;
-    }
-
-    /**
-     * Performs insert
-     *
-     * @param array $data
-     * @param string $type
-     * @throws Exception
-     * @return array|string
-     */
-    private function doInsert($data, $type)
-    {
-        // Insert single item
-
-        if (is_array(current($data)) === false) {
-            $queryObject = $this->getQuery($type, $data);
-
-            $this->fireEvents(static::EVENT_BEFORE_INSERT, $queryObject);
-            /**
-             * @var $result        \PDOStatement
-             * @var $executionTime float
-             */
-            list($result, $executionTime) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
-
-            $insertId = $result->rowCount() === 1 ? $this->pdo->lastInsertId() : null;
-            $this->fireEvents(static::EVENT_AFTER_INSERT, $queryObject, $insertId, $executionTime);
-
-            return $insertId;
-        }
-
-        $insertIds = [];
-
-        // If the current batch insert is not in a transaction, we create one...
-
-        if ($this->pdo->inTransaction() === false) {
-
-            $this->transaction(function (Transaction $transaction) use (&$insertIds, $data, $type) {
-                foreach ($data as $subData) {
-                    $insertIds[] = $transaction->doInsert($subData, $type);
-                }
-            });
-
-            return $insertIds;
-        }
-
-        // Otherwise insert one by one...
-
-        foreach ($data as $subData) {
-            $insertIds[] = $this->doInsert($subData, $type);
-        }
-
-        return $insertIds;
-    }
-
-    /**
-     * Find by value and field name.
-     *
-     * @param string|int|float $value
-     * @param string $fieldName
-     * @throws Exception
-     * @return null|\stdClass
-     */
-    public function find($value, $fieldName = 'id')
-    {
-        return $this->where($fieldName, '=', $value)->first();
-    }
-
-    /**
-     * Find all by field name and value
-     *
-     * @param string $fieldName
-     * @param string|int|float $value
-     * @throws Exception
-     * @return \stdClass[]
-     */
-    public function findAll($fieldName, $value)
-    {
-        return $this->where($fieldName, '=', $value)->get();
-    }
-
-    /**
-     * Fires event by given event name
-     *
-     * @param string $name
-     * @param ... $parameters
-     * @return mixed|null
-     */
-    public function fireEvents($name, $parameters = null)
-    {
-        $params = func_get_args();
-        array_unshift($params, $this);
-
-        return call_user_func_array([$this->connection->getEventHandler(), 'fireEvents'], $params);
-    }
-
-    /**
-     * Returns the first row
-     *
-     * @throws Exception
-     * @return \stdClass|null
-     */
-    public function first()
-    {
-        $result = $this->limit(1)->get();
-
-        return ($result !== null && count($result) > 0) ? $result[0] : null;
-    }
-
-    /**
-     * Adds FROM statement to the current query.
-     *
-     * @param string|array $tables
-     * @return static
-     */
-    public function from($tables)
-    {
-        if (is_array($tables) === false) {
-            $tables = func_get_args();
-        }
-
-        $tables = $this->addTablePrefix($tables, false);
-        $this->addStatement('tables', $tables);
-
-        return $this;
-    }
-
-    /**
-     * Get all rows
-     *
-     * @throws Exception
-     * @return \stdClass[]
-     */
-    public function get()
-    {
-        /**
-         * @var $queryObject   \Pecee\Pixie\QueryBuilder\QueryObject
-         * @var $executionTime float
-         * @var $start         float
-         * @var $result        array
-         */
-        $queryObject = null;
-        $executionTime = 0;
-
-        if ($this->pdoStatement === null) {
-            $queryObject = $this->getQuery();
-            list($this->pdoStatement, $executionTime) = $this->statement(
-                $queryObject->getSql(),
-                $queryObject->getBindings()
-            );
-        }
-
-        $start = microtime(true);
-        $this->fireEvents(static::EVENT_BEFORE_SELECT, $queryObject);
-        $result = call_user_func_array([$this->pdoStatement, 'fetchAll'], $this->fetchParameters);
-        $executionTime += microtime(true) - $start;
-        $this->pdoStatement = null;
-        $this->fireEvents(static::EVENT_AFTER_SELECT, $queryObject, $result, $executionTime);
-
-        return $result;
-    }
-
-    /**
-     * Get connection object
-     *
-     * @return Connection
-     */
-    public function getConnection()
-    {
-        return $this->connection;
-    }
-
-    /**
-     * Get event by event name
-     *
-     * @param string $name
-     * @param string|null $table
-     * @return \Closure|null
-     */
-    public function getEvent($name, $table = null)
-    {
-        return $this->connection->getEventHandler()->getEvent($name, $table);
-    }
-
-    /**
-     * Returns Query-object.
-     *
-     * @param string $type
-     * @param array|mixed|null $dataToBePassed
-     * @return QueryObject
-     * @throws Exception
-     */
-    public function getQuery($type = 'select', $dataToBePassed = null)
-    {
-        $allowedTypes = [
-            'select',
-            'insert',
-            'insertignore',
-            'replace',
-            'delete',
-            'update',
-            'criteriaonly',
-        ];
-
-        if (in_array(strtolower($type), $allowedTypes, true) === false) {
-            throw new Exception($type . ' is not a known type.', 2);
-        }
-
-        $queryArr = $this->adapterInstance->$type($this->statements, $dataToBePassed);
-
-        return new QueryObject($queryArr['sql'], $queryArr['bindings'], $this->pdo);
-    }
-
-    /**
-     * Returns statements
-     *
-     * @return array
-     */
-    public function getStatements()
-    {
-        return $this->statements;
-    }
-
-    /**
-     * Adds GROUP BY to the current query.
-     *
-     * @param string|Raw|\Closure|array $field
-     * @return static
-     */
-    public function groupBy($field)
-    {
-        if (($field instanceof Raw) === false) {
-            $field = $this->addTablePrefix($field);
-        }
-
-        if (is_array($field) === true) {
-            $this->statements['groupBys'] = array_merge($this->statements['groupBys'], $field);
-        } else {
-            $this->statements['groupBys'][] = $field;
-        }
-
-        return $this;
-    }
-
-    /**
-     * Adds HAVING statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|mixed $operator
-     * @param string|mixed $value
-     * @param string $joiner
-     * @return static
-     */
-    public function having($key, $operator, $value, $joiner = 'AND')
-    {
-        $key = $this->addTablePrefix($key);
-        $this->statements['havings'][] = compact('key', 'operator', 'value', 'joiner');
-
-        return $this;
-    }
-
-    /**
-     * Adds new INNER JOIN statement to the current query.
-     *
-     * @param string|Raw|\Closure $table
-     * @param string|Raw|\Closure $key
-     * @param string|mixed|null $operator
-     * @param string|Raw|\Closure|null $value
-     * @return static
-     */
-    public function innerJoin($table, $key, $operator = null, $value = null)
-    {
-        return $this->join($table, $key, $operator, $value);
-    }
-
-    /**
-     * Insert key/value array
-     *
-     * @param array $data
-     * @throws Exception
-     * @return array|string
-     */
-    public function insert($data)
-    {
-        return $this->doInsert($data, 'insert');
-    }
-
-    /**
-     * Insert with ignore key/value array
-     *
-     * @param array $data
-     * @throws Exception
-     * @return array|string
-     */
-    public function insertIgnore($data)
-    {
-        return $this->doInsert($data, 'insertignore');
-    }
-
-    /**
-     * Adds new JOIN statement to the current query.
-     *
-     * @param string|Raw|\Closure $table
-     * @param string|Raw|\Closure $key
-     * @param string|null $operator
-     * @param string|Raw|\Closure $value
-     * @param string $type
-     * @throws Exception
-     * @return static
-     */
-    public function join($table, $key, $operator = null, $value = null, $type = 'inner')
-    {
-        if (($key instanceof \Closure) === false) {
-            $key = function (JoinBuilder $joinBuilder) use ($key, $operator, $value) {
-                $joinBuilder->on($key, $operator, $value);
-            };
-        }
-
-        /**
-         * Build a new JoinBuilder class, keep it by reference so any changes made
-         * in the closure should reflect here
-         */
-
-        $joinBuilder = new JoinBuilder($this->connection);
-
-        // Call the closure with our new joinBuilder object
-        $key($joinBuilder);
-        $table = $this->addTablePrefix($table, false);
-
-        // Get the criteria only query from the joinBuilder object
-        $this->statements['joins'][] = compact('type', 'table', 'joinBuilder');
-
-        return $this;
-    }
-
-    /**
-     * Adds new LEFT JOIN statement to the current query.
-     *
-     * @param string|Raw|\Closure $table
-     * @param string|Raw|\Closure $key
-     * @param string|null $operator
-     * @param string|Raw|\Closure|null $value
-     * @return static
-     */
-    public function leftJoin($table, $key, $operator = null, $value = null)
-    {
-        return $this->join($table, $key, $operator, $value, 'left');
-    }
-
-    /**
-     * Adds LIMIT statement to the current query.
-     *
-     * @param int $limit
-     * @return static
-     */
-    public function limit($limit)
-    {
-        $this->statements['limit'] = $limit;
-
-        return $this;
-    }
-
-    /**
-     * Creates and returns new query.
-     *
-     * @param \Pecee\Pixie\Connection|null $connection
-     * @throws \Pecee\Pixie\Exception
-     * @return static
-     */
-    public function newQuery(Connection $connection = null)
-    {
-        if ($connection === null) {
-            $connection = $this->connection;
-        }
-
-        return new static($connection);
-    }
-
-    /**
-     * Adds OFFSET statement to the current query.
-     *
-     * @param int $offset
-     * @return static $this
-     */
-    public function offset($offset)
-    {
-        $this->statements['offset'] = $offset;
-
-        return $this;
-    }
-
-    /**
-     * Add on duplicate key statement.
-     *
-     * @param string $data
-     * @return static
-     */
-    public function onDuplicateKeyUpdate($data)
-    {
-        $this->addStatement('onduplicate', $data);
-
-        return $this;
-    }
-
-    /**
-     * Adds OR HAVING statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|Raw|\Closure $operator
-     * @param mixed|Raw|\Closure|null $value
-     * @return static
-     */
-    public function orHaving($key, $operator, $value)
-    {
-        return $this->having($key, $operator, $value, 'OR');
-    }
-
-    /**
-     * Adds OR WHERE statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|null $operator
-     * @param mixed|Raw|\Closure|null $value
-     * @return static
-     */
-    public function orWhere($key, $operator = null, $value = null)
-    {
-        // If two params are given then assume operator is =
-        if (func_num_args() === 2) {
-            $value = $operator;
-            $operator = '=';
-        }
-
-        return $this->whereHandler($key, $operator, $value, 'OR');
-    }
-
-    /**
-     * Adds OR WHERE BETWEEN statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|integer|float $valueFrom
-     * @param string|integer|float $valueTo
-     * @return static
-     */
-    public function orWhereBetween($key, $valueFrom, $valueTo)
-    {
-        return $this->whereHandler($key, 'BETWEEN', [$valueFrom, $valueTo], 'OR');
-    }
-
-    /**
-     * Adds OR WHERE IN statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param array|Raw|\Closure $values
-     * @return static
-     */
-    public function orWhereIn($key, $values)
-    {
-        return $this->whereHandler($key, 'IN', $values, 'OR');
-    }
-
-    /**
-     * Adds OR WHERE NOT statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|array|Raw|\Closure|null $operator
-     * @param mixed|Raw|\Closure|null $value
-     * @return static
-     */
-    public function orWhereNot($key, $operator = null, $value = null)
-    {
-        // If two params are given then assume operator is =
-        if (func_num_args() === 2) {
-            $value = $operator;
-            $operator = '=';
-        }
-
-        return $this->whereHandler($key, $operator, $value, 'OR NOT');
-    }
-
-    /**
-     * Adds or WHERE NOT IN statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param array|Raw|\Closure $values
-     * @return static
-     */
-    public function orWhereNotIn($key, $values)
-    {
-        return $this->whereHandler($key, 'NOT IN', $values, 'OR');
-    }
-
-    /**
-     * Adds OR WHERE NOT NULL statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @return QueryBuilderHandler
-     */
-    public function orWhereNotNull($key)
-    {
-        return $this->whereNullHandler($key, 'NOT', 'or');
-    }
-
-    /**
-     * Adds OR WHERE NULL statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @return QueryBuilderHandler
-     */
-    public function orWhereNull($key)
-    {
-        return $this->whereNullHandler($key, '', 'or');
-    }
-
-    /**
-     * Adds ORDER BY statement to the current query.
-     *
-     * @param string|Raw|\Closure|array $fields
-     * @param string $defaultDirection
-     * @return static
-     */
-    public function orderBy($fields, $defaultDirection = 'ASC')
-    {
-        if (is_array($fields) === false) {
-            $fields = [$fields];
-        }
-
-        foreach ((array)$fields as $key => $value) {
-            $field = $key;
-            $type = $value;
-
-            if (is_int($key) === true) {
-                $field = $value;
-                $type = $defaultDirection;
-            }
-
-            if (($field instanceof Raw) === false) {
-                $field = $this->addTablePrefix($field);
-            }
-
-            $this->statements['orderBys'][] = compact('field', 'type');
-        }
-
-        return $this;
-    }
-
-    /**
-     * Return PDO instance
-     *
-     * @return PDO
-     */
-    public function pdo()
-    {
-        return $this->pdo;
-    }
-
-    /**
-     * Performs query.
-     *
-     * @param string $sql
-     * @param array $bindings
-     * @return static
-     */
-    public function query($sql, array $bindings = [])
-    {
-        list($this->pdoStatement) = $this->statement($sql, $bindings);
-
-        return $this;
-    }
-
-    /**
-     * Adds a raw string to the current query.
-     * This query will be ignored from any parsing or formatting by the Query builder
-     * and should be used in conjunction with other statements in the query.
-     *
-     * For example: $qb->where('result', '>', $qb->raw('COUNT(`score`)));
-     *
-     * @param string $value
-     * @param array|null|mixed $bindings ...
-     * @return Raw
-     */
-    public function raw($value, $bindings = null)
-    {
-        if (is_array($bindings) === false) {
-            $bindings = func_get_args();
-            array_shift($bindings);
-        }
-
-        return new Raw($value, $bindings);
-    }
-
-    /**
-     * Register new event
-     *
-     * @param string $name
-     * @param string|null $table
-     * @param \Closure $action
-     * @return void
-     */
-    public function registerEvent($name, $table = null, \Closure $action)
-    {
-        $this->connection->getEventHandler()->registerEvent($name, $table, $action);
-    }
-
-    /**
-     * Remove event by event-name and/or table
-     *
-     * @param string $name
-     * @param string|null $table
-     * @return void
-     */
-    public function removeEvent($name, $table = null)
-    {
-        $this->connection->getEventHandler()->removeEvent($name, $table);
-    }
-
-    /**
-     * Replace key/value array
-     *
-     * @param array $data
-     * @throws Exception
-     * @return array|string
-     */
-    public function replace($data)
-    {
-        return $this->doInsert($data, 'replace');
-    }
-
-    /**
-     * Adds new right join statement to the current query.
-     *
-     * @param string|Raw|\Closure $table
-     * @param string|Raw|\Closure $key
-     * @param string|null $operator
-     * @param string|Raw|\Closure|null $value
-     * @return static
-     */
-    public function rightJoin($table, $key, $operator = null, $value = null)
-    {
-        return $this->join($table, $key, $operator, $value, 'right');
-    }
-
-    /**
-     * Adds fields to select on the current query (defaults is all).
-     * You can use key/value array to create alias.
-     * Sub-queries and raw-objects are also supported.
-     *
-     * Example: ['field' => 'alias'] will become `field` AS `alias`
-     *
-     * @param string|array $fields,...
-     * @return static
-     */
-    public function select($fields)
-    {
-        if (is_array($fields) === false) {
-            $fields = func_get_args();
-        }
-
-        $fields = $this->addTablePrefix($fields);
-        $this->addStatement('selects', $fields);
-
-        return $this;
-    }
-
-    /**
-     * Performs select distinct on the current query.
-     *
-     * @param string|Raw|\Closure|array $fields
-     * @return static
-     */
-    public function selectDistinct($fields)
-    {
-        $this->select($fields);
-        $this->addStatement('distinct', true);
-
-        return $this;
-    }
-
-    /**
-     * Set connection object
-     *
-     * @param Connection $connection
-     * @return static
-     */
-    public function setConnection(Connection $connection)
-    {
-        $this->connection = $connection;
-
-        return $this;
-    }
-
-    /**
-     * Add fetch parameters to the PDO-query.
-     *
-     * @param mixed $parameters ...
-     * @return static
-     */
-    public function setFetchMode($parameters = null)
-    {
-        $this->fetchParameters = func_get_args();
-
-        return $this;
-    }
-
-    /**
-     * Execute statement
-     *
-     * @param string $sql
-     * @param array $bindings
-     * @return array PDOStatement and execution time as float
-     */
-    public function statement($sql, array $bindings = [])
-    {
-        $start = microtime(true);
-
-        $pdoStatement = $this->pdo->prepare($sql);
-
-        $pdoStatement->execute($bindings);
-
-        return [$pdoStatement, microtime(true) - $start];
-    }
-
-    /**
-     * Performs new sub-query.
-     * Call this method when you want to add a new sub-query in your where etc.
-     *
-     * @param QueryBuilderHandler $queryBuilder
-     * @param string|null $alias
-     * @throws Exception
-     * @return Raw
-     */
-    public function subQuery(QueryBuilderHandler $queryBuilder, $alias = null)
-    {
-        $sql = '(' . $queryBuilder->getQuery()->getRawSql() . ')';
-        if ($alias !== null) {
-            $sql = $sql . ' AS ' . $this->adapterInstance->wrapSanitizer($alias);
-        }
-
-        return $queryBuilder->raw($sql);
-    }
-
-    /**
-     * Sets the table that the query is using
-     *
-     * @param string|array $tables Single table or multiple tables as an array or as multiple parameters
-     * @throws Exception
-     * @return static
-     */
-    public function table($tables)
-    {
-        $tTables = [];
-
-        if (is_array($tables) === false) {
-            // Because a single table is converted to an array anyways, this makes sense.
-            $tables = \func_get_args();
-        }
-
-        $instance = new static($this->connection);
-
-        foreach ($tables as $key => $value) {
-            if (is_string($key)) {
-                $instance->alias($value, $key);
-                $tTables[] = $key;
-            } else {
-                $tTables[] = $value;
-            }
-        }
-
-        $tTables = $this->addTablePrefix($tTables, false);
-        $instance->addStatement('tables', $tTables);
-
-        return $instance;
-    }
-
-    /**
-     * Performs the transaction
-     *
-     * @param \Closure $callback
-     * @return static
-     * @throws Exception
-     */
-    public function transaction(\Closure $callback)
-    {
-        /**
-         * Get the Transaction class
-         *
-         * @var \Pecee\Pixie\QueryBuilder\Transaction $queryTransaction
-         * @throws \Exception
-         */
-        $queryTransaction = new Transaction($this->connection);
-        $queryTransaction->statements = $this->statements;
-
-        try {
-            // Begin the PDO transaction
-            if($this->pdo->inTransaction() === false) {
-                $this->pdo->beginTransaction();
-            }
-
-            // Call closure - this callback will return TransactionHaltException if user has already committed the transaction
-            $callback($queryTransaction);
-
-            // If no errors have been thrown or the transaction wasn't completed within the closure, commit the changes
-            $this->pdo->commit();
-
-        } catch (TransactionHaltException $e) {
-
-            // Commit or rollback behavior has been triggered in the closure
-            return $this;
-
-        } catch (\Exception $e) {
-
-            // Something went wrong. Rollback and throw Exception
-            if($this->pdo->inTransaction() === true) {
-                $this->pdo->rollBack();
-            }
-
-            throw new Exception($e->getMessage());
-        }
-
-        return $queryTransaction;
-    }
-
-    /**
-     * Update key/value array
-     *
-     * @param array $data
-     * @throws Exception
-     * @return \PDOStatement
-     */
-    public function update($data)
-    {
-        /**
-         * @var $response \PDOStatement
-         */
-        $queryObject = $this->getQuery('update', $data);
-
-        $this->fireEvents(static::EVENT_BEFORE_UPDATE, $queryObject);
-
-        list($response, $executionTime) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
-        $this->fireEvents(static::EVENT_AFTER_UPDATE, $queryObject, $executionTime);
-
-        return $response;
-    }
-
-    /**
-     * Update or insert key/value array
-     *
-     * @param array $data
-     * @return array|\PDOStatement|string
-     * @throws Exception
-     */
-    public function updateOrInsert($data)
-    {
-        if ($this->first() !== null) {
-            return $this->update($data);
-        }
-
-        return $this->insert($data);
-    }
-
-    /**
-     * Adds WHERE statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|Raw|\Closure|null $operator
-     * @param mixed|Raw|\Closure|null $value
-     * @return static
-     */
-    public function where($key, $operator = null, $value = null)
-    {
-        // If two params are given then assume operator is =
-        if (func_num_args() === 2) {
-            $value = $operator;
-            $operator = '=';
-        }
-
-        if (is_bool($value) === true) {
-            $value = (int)$value;
-        }
-
-        return $this->whereHandler($key, $operator, $value);
-    }
-
-    /**
-     * Adds WHERE BETWEEN statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|integer|float $valueFrom
-     * @param string|integer|float $valueTo
-     * @return static
-     */
-    public function whereBetween($key, $valueFrom, $valueTo)
-    {
-        return $this->whereHandler($key, 'BETWEEN', [$valueFrom, $valueTo]);
-    }
-
-    /**
-     * Handles where statements
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|Raw|\Closure|null $operator
-     * @param string|Raw|\Closure|null $value
-     * @param string $joiner
-     * @return static
-     */
-    protected function whereHandler($key, $operator = null, $value = null, $joiner = 'AND')
-    {
-        $key = $this->addTablePrefix($key);
-        $this->statements['wheres'][] = compact('key', 'operator', 'value', 'joiner');
-
-        return $this;
-    }
-
-    /**
-     * Adds WHERE IN statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param array|Raw|\Closure $values
-     * @return static
-     */
-    public function whereIn($key, $values)
-    {
-        return $this->whereHandler($key, 'IN', $values);
-    }
-
-    /**
-     * Adds WHERE NOT statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string|array|Raw|\Closure|null $operator
-     * @param mixed|Raw|\Closure|null $value
-     * @return static
-     */
-    public function whereNot($key, $operator = null, $value = null)
-    {
-        // If two params are given then assume operator is =
-        if (func_num_args() === 2) {
-            $value = $operator;
-            $operator = '=';
-        }
-
-        return $this->whereHandler($key, $operator, $value, 'AND NOT');
-    }
-
-    /**
-     * Adds OR WHERE NOT IN statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @param array|Raw|\Closure $values
-     * @return static
-     */
-    public function whereNotIn($key, $values)
-    {
-        return $this->whereHandler($key, 'NOT IN', $values);
-    }
-
-    /**
-     * Adds WHERE NOT NULL statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @return QueryBuilderHandler
-     */
-    public function whereNotNull($key)
-    {
-        return $this->whereNullHandler($key, 'NOT');
-    }
-
-    /**
-     * Adds WHERE NULL statement to the current query.
-     *
-     * @param string|Raw|\Closure $key
-     * @return QueryBuilderHandler
-     */
-    public function whereNull($key)
-    {
-        return $this->whereNullHandler($key);
-    }
-
-    /**
-     * Handles WHERE NULL statements.
-     *
-     * @param string|Raw|\Closure $key
-     * @param string $prefix
-     * @param string $operator
-     * @return mixed
-     */
-    protected function whereNullHandler($key, $prefix = '', $operator = '')
-    {
-        $key = $this->adapterInstance->wrapSanitizer($this->addTablePrefix($key));
-        $prefix = ($prefix !== '') ? $prefix . ' ' : $prefix;
-
-        return $this->{$operator . 'Where'}($this->raw("$key IS {$prefix}NULL"));
-    }
+class QueryBuilderHandler {
+	/**
+	 * @var Connection
+	 */
+	protected $connection;
+
+	/**
+	 * @var array
+	 */
+	protected $statements = [
+		'groupBys' => [],
+	];
+
+	/**
+	 * @var \PDO
+	 */
+	protected $pdo;
+
+	/**
+	 * @var null|\PDOStatement
+	 */
+	protected $pdoStatement;
+
+	/**
+	 * @var null|string
+	 */
+	protected $tablePrefix;
+
+	/**
+	 * @var \Pecee\Pixie\QueryBuilder\Adapters\BaseAdapter
+	 */
+	protected $adapterInstance;
+
+	/**
+	 * The PDO fetch parameters to use
+	 *
+	 * @var array
+	 */
+	protected $fetchParameters = [\PDO::FETCH_OBJ];
+
+	/**
+	 * @var string
+	 */
+	protected $adapter;
+
+	/**
+	 * @var array
+	 */
+	protected $adapterConfig;
+
+	/**
+	 * @param \Pecee\Pixie\Connection|null $connection
+	 *
+	 * @throws \Pecee\Pixie\Exception
+	 */
+	public function __construct(Connection $connection = null) {
+		if ($connection === null && ($connection = Connection::getStoredConnection()) === false) {
+			throw new Exception('No database connection found.', 1);
+		}
+
+		$this->connection    = $connection;
+		$this->pdo           = $this->connection->getPdoInstance();
+		$this->adapter       = $this->connection->getAdapter();
+		$this->adapterConfig = $this->connection->getAdapterConfig();
+
+		if (isset($this->adapterConfig['prefix']) === true) {
+			$this->tablePrefix = $this->adapterConfig['prefix'];
+		}
+
+		// Query builder adapter instance
+		$adapterClass          = $this->adapter->getQueryAdapterClass();
+		$this->adapterInstance = new $adapterClass($this->connection);
+
+		$this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+		// PDO will parse parameter datatypes automatically
+		$this->pdo->setAttribute(PDO::ATTR_EMULATE_PREPARES, true);
+	}
+
+	/**
+	 * Add new statement to statement-list
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 *
+	 * @return void
+	 */
+	protected function addStatement($key, $value) {
+		if (array_key_exists($key, $this->statements) === false) {
+			$this->statements[ $key ] = (array)$value;
+		} else {
+			$this->statements[ $key ] = array_merge($this->statements[ $key ], (array)$value);
+		}
+	}
+
+	/**
+	 * Add table prefix (if given) on given string.
+	 *
+	 * @param string|array|Raw|\Closure $values
+	 * @param bool $tableFieldMix If we have mixes of field and table names with a "."
+	 *
+	 * @return array|string
+	 */
+	public function addTablePrefix($values, $tableFieldMix = true) {
+		if ($this->tablePrefix === null) {
+			return $values;
+		}
+
+		// $value will be an array and we will add prefix to all table names
+		// If supplied value is not an array then make it one
+
+		$single = false;
+		if (is_array($values) === false) {
+			$values = [$values];
+
+			// We had single value, so should return a single value
+			$single = true;
+		}
+
+		$return = [];
+
+		foreach ($values as $key => $value) {
+			// It's a raw query, just add it to our return array and continue next
+			if ($value instanceof Raw || $value instanceof \Closure) {
+				$return[ $key ] = $value;
+				continue;
+			}
+
+			// If key is not integer, it is likely a alias mapping, so we need to change prefix target
+			$target = &$value;
+
+			if (is_int($key) === false) {
+				$target = &$key;
+			}
+
+			if ($tableFieldMix === false || ($tableFieldMix && strpos($target, '.') !== false)) {
+				$target = $this->tablePrefix . $target;
+			}
+
+			$return[ $key ] = $value;
+		}
+
+		// If we had single value then we should return a single value (end value of the array)
+		return $single ? end($return) : $return;
+	}
+
+	/**
+	 * Performs special queries like COUNT, SUM etc based on the current query.
+	 *
+	 * @param string $type
+	 *
+	 * @throws Exception
+	 * @return int
+	 */
+	protected function aggregate($type) {
+		// Get the current selects
+		$mainSelects = isset($this->statements['selects']) === true ? $this->statements['selects'] : null;
+
+		// Replace select with a scalar value like `count`
+		$this->statements['selects'] = [$this->raw($type . '(*) AS `field`')];
+		$row                         = $this->get();
+
+		// Set the select as it was
+		if ($mainSelects !== null) {
+			$this->statements['selects'] = $mainSelects;
+		} else {
+			unset($this->statements['selects']);
+		}
+
+		if (isset($row[0]) === true) {
+			if (is_array($row[0]) === true) {
+				return (int)$row[0]['field'];
+			}
+			if (is_object($row[0]) === true) {
+				return (int)$row[0]->field;
+			}
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Add or change table alias
+	 * Example: table AS alias
+	 *
+	 * @param string $alias
+	 * @param string $table
+	 *
+	 * @return static
+	 */
+	public function alias($alias, $table = null) {
+		if ($table === null && isset($this->statements['tables'][0]) === true) {
+			$table = $this->statements['tables'][0];
+		} else {
+			$table = $this->tablePrefix . $table;
+		}
+
+		$this->statements['aliases'][ $table ] = strtolower($alias);
+
+		return $this;
+	}
+
+	/**
+	 * Fetch query results as object of specified type
+	 *
+	 * @param string $className
+	 * @param array $constructorArgs
+	 *
+	 * @return static
+	 */
+	public function asObject($className, array $constructorArgs = []) {
+		return $this->setFetchMode(\PDO::FETCH_CLASS, $className, $constructorArgs);
+	}
+
+	/**
+	 * Get count of rows
+	 *
+	 * @throws Exception
+	 * @return int
+	 */
+	public function count() {
+		// Get the current statements
+		$originalStatements = $this->statements;
+
+		unset($this->statements['orderBys'], $this->statements['limit'], $this->statements['offset']);
+
+		$count            = $this->aggregate('count');
+		$this->statements = $originalStatements;
+
+		return $count;
+	}
+
+	/**
+	 * Forms delete on the current query.
+	 *
+	 * @return \PDOStatement
+	 * @throws Exception
+	 */
+	public function delete() {
+		/* @var $response \PDOStatement */
+		$queryObject = $this->getQuery('delete');
+
+		$this->fireEvents(EventHandler::EVENT_BEFORE_DELETE, $queryObject);
+
+		list($response, $executionTime) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
+		$this->fireEvents(EventHandler::EVENT_AFTER_DELETE, $queryObject, $executionTime);
+
+		return $response;
+	}
+
+	/**
+	 * Performs insert
+	 *
+	 * @param array $data
+	 * @param string $type
+	 *
+	 * @throws Exception
+	 * @return array|string|null
+	 */
+	private function doInsert($data, $type) {
+		// Insert single item
+
+		if (is_array(current($data)) === false) {
+			$queryObject = $this->getQuery($type, $data);
+
+			$this->fireEvents(EventHandler::EVENT_BEFORE_INSERT, $queryObject);
+			/**
+			 * @var $result        \PDOStatement
+			 * @var $executionTime float
+			 */
+			list($result, $executionTime) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
+
+			$insertId = $result->rowCount() === 1 ? $this->pdo->lastInsertId() : null;
+			$this->fireEvents(EventHandler::EVENT_AFTER_INSERT, $queryObject, $insertId, $executionTime);
+
+			return $insertId;
+		}
+
+		$insertIds = [];
+
+		// If the current batch insert is not in a transaction, we create one...
+
+		if ($this->pdo->inTransaction() === false) {
+
+			$this->transaction(function (Transaction $transaction) use (&$insertIds, $data, $type) {
+				foreach ($data as $subData) {
+					$insertIds[] = $transaction->doInsert($subData, $type);
+				}
+			});
+
+			return $insertIds;
+		}
+
+		// Otherwise insert one by one...
+
+		foreach ($data as $subData) {
+			$insertIds[] = $this->doInsert($subData, $type);
+		}
+
+		return $insertIds;
+	}
+
+	/**
+	 * Find by value and field name.
+	 *
+	 * @param string|int|float $value
+	 * @param string $fieldName
+	 *
+	 * @throws Exception
+	 * @return \stdClass|string|null
+	 */
+	public function find($value, $fieldName = 'id') {
+		return $this->where($fieldName, '=', $value)->first();
+	}
+
+	/**
+	 * Find all by field name and value
+	 *
+	 * @param string $fieldName
+	 * @param string|int|float $value
+	 *
+	 * @throws Exception
+	 * @return array
+	 */
+	public function findAll($fieldName, $value) {
+		return $this->where($fieldName, '=', $value)->get();
+	}
+
+	/**
+	 * Fires event by given event name
+	 *
+	 * @param string $name
+	 * @param ... $parameters
+	 *
+	 * @return mixed|null
+	 */
+	public function fireEvents($name, $parameters = null) {
+		$params = func_get_args();
+		array_unshift($params, $this);
+
+		return call_user_func_array([$this->connection->getEventHandler(), 'fireEvents'], $params);
+	}
+
+	/**
+	 * Returns the first row
+	 *
+	 * @throws Exception
+	 * @return \stdClass|string|null
+	 */
+	public function first() {
+		$result = $this->limit(1)->get();
+
+		return ($result !== null && count($result) > 0) ? $result[0] : null;
+	}
+
+	/**
+	 * Adds FROM statement to the current query.
+	 *
+	 * @param string|array $tables
+	 *
+	 * @return static
+	 */
+	public function from($tables) {
+		if (is_array($tables) === false) {
+			$tables = func_get_args();
+		}
+
+		$tables = $this->addTablePrefix($tables, false);
+		$this->addStatement('tables', $tables);
+
+		return $this;
+	}
+
+	/**
+	 * Get all rows
+	 *
+	 * @throws Exception
+	 * @return array
+	 */
+	public function get() {
+		/**
+		 * @var $queryObject   \Pecee\Pixie\QueryBuilder\QueryObject
+		 * @var $executionTime float
+		 * @var $start         float
+		 * @var $result        array
+		 */
+		$queryObject   = null;
+		$executionTime = 0;
+
+		if ($this->pdoStatement === null) {
+			$queryObject = $this->getQuery();
+			list($this->pdoStatement, $executionTime) = $this->statement(
+				$queryObject->getSql(),
+				$queryObject->getBindings()
+			);
+		}
+
+		$start = microtime(true);
+		$this->fireEvents(EventHandler::EVENT_BEFORE_SELECT, $queryObject);
+		$result             = call_user_func_array([$this->pdoStatement, 'fetchAll'], $this->fetchParameters);
+		$executionTime      += microtime(true) - $start;
+		$this->pdoStatement = null;
+		$this->fireEvents(EventHandler::EVENT_AFTER_SELECT, $queryObject, $result, $executionTime);
+
+		return $result;
+	}
+
+	/**
+	 * Get connection object
+	 *
+	 * @return Connection
+	 */
+	public function getConnection() {
+		return $this->connection;
+	}
+
+	/**
+	 * Get event by event name
+	 *
+	 * @param string $name
+	 * @param string|null $table
+	 *
+	 * @return \Closure|null
+	 */
+	public function getEvent($name, $table = null) {
+		return $this->connection->getEventHandler()->getEvent($name, $table);
+	}
+
+	/**
+	 * Returns Query-object.
+	 *
+	 * @param string $type
+	 * @param array|mixed|null $dataToBePassed
+	 *
+	 * @return QueryObject
+	 * @throws Exception
+	 */
+	public function getQuery($type = 'select', $dataToBePassed = null) {
+		$allowedTypes = [
+			'select',
+			'insert',
+			'insertignore',
+			'replace',
+			'delete',
+			'update',
+			'criteriaonly',
+		];
+
+		if (in_array(strtolower($type), $allowedTypes, true) === false) {
+			throw new Exception($type . ' is not a known type.', 2);
+		}
+
+		$queryArr = $this->adapterInstance->$type($this->statements, $dataToBePassed);
+
+		return new QueryObject($queryArr['sql'], $queryArr['bindings'], $this->pdo);
+	}
+
+	/**
+	 * Returns statements
+	 *
+	 * @return array
+	 */
+	public function getStatements() {
+		return $this->statements;
+	}
+
+	/**
+	 * Adds GROUP BY to the current query.
+	 *
+	 * @param string|Raw|\Closure|array $field
+	 *
+	 * @return static
+	 */
+	public function groupBy($field) {
+		if (($field instanceof Raw) === false) {
+			$field = $this->addTablePrefix($field);
+		}
+
+		if (is_array($field) === true) {
+			$this->statements['groupBys'] = array_merge($this->statements['groupBys'], $field);
+		} else {
+			$this->statements['groupBys'][] = $field;
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Adds HAVING statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 * @param string|mixed $operator
+	 * @param string|mixed $value
+	 * @param string $joiner
+	 *
+	 * @return static
+	 */
+	public function having($key, $operator, $value, $joiner = 'AND') {
+		$key                           = $this->addTablePrefix($key);
+		$this->statements['havings'][] = compact('key', 'operator', 'value', 'joiner');
+
+		return $this;
+	}
+
+	/**
+	 * Adds new INNER JOIN statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $table
+	 * @param string|Raw|\Closure $key
+	 * @param string|mixed|null $operator
+	 * @param string|Raw|\Closure|null $value
+	 *
+	 * @return static
+	 * @throws Exception
+	 */
+	public function innerJoin($table, $key, $operator = null, $value = null) {
+		return $this->join($table, $key, $operator, $value);
+	}
+
+	/**
+	 * Insert key/value array
+	 *
+	 * @param array $data
+	 *
+	 * @throws Exception
+	 * @return array|string
+	 */
+	public function insert($data) {
+		return $this->doInsert($data, 'insert');
+	}
+
+	/**
+	 * Insert with ignore key/value array
+	 *
+	 * @param array $data
+	 *
+	 * @throws Exception
+	 * @return array|string
+	 */
+	public function insertIgnore($data) {
+		return $this->doInsert($data, 'insertignore');
+	}
+
+	/**
+	 * Adds new JOIN statement to the current query.
+	 *
+	 * @param string|Raw|\Closure|array $table
+	 * @param string|Raw|\Closure $key
+	 * @param string|null $operator
+	 * @param string|Raw|\Closure $value
+	 * @param string $type
+	 *
+	 * @return static
+	 * @throws Exception
+	 *
+	 * ```
+	 * Examples:
+	 * - basic usage
+	 * ->join('table2', 'table2.person_id', '=', 'table1.id');
+	 *
+	 * - as alias 'bar'
+	 * ->join(['table2','bar'], 'bar.person_id', '=', 'table1.id');
+	 *
+	 * - complex usage
+	 * ->join('another_table', function($table)
+	 * {
+	 *  $table->on('another_table.person_id', '=', 'my_table.id');
+	 *  $table->on('another_table.person_id2', '=', 'my_table.id2');
+	 *  $table->orOn('another_table.age', '>', $queryBuilder->raw(1));
+	 * })
+	 * ```
+	 */
+	public function join($table, $key, $operator = null, $value = null, $type = 'inner') {
+		if (($key instanceof \Closure) === false) {
+			$key = function (JoinBuilder $joinBuilder) use ($key, $operator, $value) {
+				$joinBuilder->on($key, $operator, $value);
+			};
+		}
+
+		/**
+		 * Build a new JoinBuilder class, keep it by reference so any changes made
+		 * in the closure should reflect here
+		 */
+
+		$joinBuilder = new JoinBuilder($this->connection);
+
+		// Call the closure with our new joinBuilder object
+		$key($joinBuilder);
+		$table = $this->addTablePrefix($table, false);
+
+		// Get the criteria only query from the joinBuilder object
+		$this->statements['joins'][] = compact('type', 'table', 'joinBuilder');
+
+		return $this;
+	}
+
+	/**
+	 * Adds new LEFT JOIN statement to the current query.
+	 *
+	 * @param string|Raw|\Closure|array $table
+	 * @param string|Raw|\Closure $key
+	 * @param string|null $operator
+	 * @param string|Raw|\Closure|null $value
+	 *
+	 * @return static
+	 * @throws Exception
+	 */
+	public function leftJoin($table, $key, $operator = null, $value = null) {
+		return $this->join($table, $key, $operator, $value, 'left');
+	}
+
+	/**
+	 * Adds LIMIT statement to the current query.
+	 *
+	 * @param int $limit
+	 *
+	 * @return static
+	 */
+	public function limit($limit) {
+		$this->statements['limit'] = $limit;
+
+		return $this;
+	}
+
+	/**
+	 * Creates and returns new query.
+	 *
+	 * @param \Pecee\Pixie\Connection|null $connection
+	 *
+	 * @return static
+	 * @throws Exception
+	 */
+	public function newQuery(Connection $connection = null) {
+		if ($connection === null) {
+			$connection = $this->connection;
+		}
+
+		return new static($connection);
+	}
+
+	/**
+	 * Adds OFFSET statement to the current query.
+	 *
+	 * @param int $offset
+	 *
+	 * @return static $this
+	 */
+	public function offset($offset) {
+		$this->statements['offset'] = $offset;
+
+		return $this;
+	}
+
+	/**
+	 * Add on duplicate key statement.
+	 *
+	 * @param string|array $data
+	 *
+	 * @return static
+	 */
+	public function onDuplicateKeyUpdate($data) {
+		$this->addStatement('onduplicate', $data);
+
+		return $this;
+	}
+
+	/**
+	 * Adds OR HAVING statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 * @param string|Raw|\Closure $operator
+	 * @param mixed|Raw|\Closure|null $value
+	 *
+	 * @return static
+	 */
+	public function orHaving($key, $operator, $value) {
+		return $this->having($key, $operator, $value, 'OR');
+	}
+
+	/**
+	 * Adds OR WHERE statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 * @param string|null $operator
+	 * @param mixed|Raw|\Closure|null $value
+	 *
+	 * @return static
+	 */
+	public function orWhere($key, $operator = null, $value = null) {
+		// If two params are given then assume operator is =
+		if (func_num_args() === 2) {
+			$value    = $operator;
+			$operator = '=';
+		}
+
+		return $this->whereHandler($key, $operator, $value, 'OR');
+	}
+
+	/**
+	 * Adds OR WHERE BETWEEN statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 * @param string|integer|float $valueFrom
+	 * @param string|integer|float $valueTo
+	 *
+	 * @return static
+	 */
+	public function orWhereBetween($key, $valueFrom, $valueTo) {
+		return $this->whereHandler($key, 'BETWEEN', [$valueFrom, $valueTo], 'OR');
+	}
+
+	/**
+	 * Adds OR WHERE IN statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 * @param array|Raw|\Closure $values
+	 *
+	 * @return static
+	 */
+	public function orWhereIn($key, $values) {
+		return $this->whereHandler($key, 'IN', $values, 'OR');
+	}
+
+	/**
+	 * Adds OR WHERE NOT statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 * @param string|null $operator
+	 * @param mixed|Raw|\Closure|null $value
+	 *
+	 * @return static
+	 */
+	public function orWhereNot($key, $operator = null, $value = null) {
+		// If two params are given then assume operator is =
+		if (func_num_args() === 2) {
+			$value    = $operator;
+			$operator = '=';
+		}
+
+		return $this->whereHandler($key, $operator, $value, 'OR NOT');
+	}
+
+	/**
+	 * Adds or WHERE NOT IN statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 * @param array|Raw|\Closure $values
+	 *
+	 * @return static
+	 */
+	public function orWhereNotIn($key, $values) {
+		return $this->whereHandler($key, 'NOT IN', $values, 'OR');
+	}
+
+	/**
+	 * Adds OR WHERE NOT NULL statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 *
+	 * @return static
+	 */
+	public function orWhereNotNull($key) {
+		return $this->whereNullHandler($key, 'NOT', 'or');
+	}
+
+	/**
+	 * Adds OR WHERE NULL statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 *
+	 * @return static
+	 */
+	public function orWhereNull($key) {
+		return $this->whereNullHandler($key, '', 'or');
+	}
+
+	/**
+	 * Adds ORDER BY statement to the current query.
+	 *
+	 * @param string|Raw|\Closure|array $fields
+	 * @param string $defaultDirection
+	 *
+	 * @return static
+	 */
+	public function orderBy($fields, $defaultDirection = 'ASC') {
+		if (is_array($fields) === false) {
+			$fields = [$fields];
+		}
+
+		foreach ((array)$fields as $key => $value) {
+			$field = $key;
+			$type  = $value;
+
+			if (is_int($key) === true) {
+				$field = $value;
+				$type  = $defaultDirection;
+			}
+
+			if (($field instanceof Raw) === false) {
+				$field = $this->addTablePrefix($field);
+			}
+
+			$this->statements['orderBys'][] = compact('field', 'type');
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Return PDO instance
+	 *
+	 * @return PDO
+	 */
+	public function pdo() {
+		return $this->pdo;
+	}
+
+	/**
+	 * Performs query.
+	 *
+	 * @param string $sql
+	 * @param array $bindings
+	 *
+	 * @return static
+	 */
+	public function query($sql, array $bindings = []) {
+		list($this->pdoStatement) = $this->statement($sql, $bindings);
+
+		return $this;
+	}
+
+	/**
+	 * Adds a raw string to the current query.
+	 * This query will be ignored from any parsing or formatting by the Query builder
+	 * and should be used in conjunction with other statements in the query.
+	 *
+	 * For example: $qb->where('result', '>', $qb->raw('COUNT(`score`)));
+	 *
+	 * @param string $value
+	 * @param array|null|mixed $bindings ...
+	 *
+	 * @return Raw
+	 */
+	public function raw($value, $bindings = null) {
+		if (is_array($bindings) === false) {
+			$bindings = func_get_args();
+			array_shift($bindings);
+		}
+
+		return new Raw($value, $bindings);
+	}
+
+	/**
+	 * Register new event
+	 *
+	 * @param string $name
+	 * @param string|null $table
+	 * @param \Closure $action
+	 *
+	 * @return void
+	 */
+	public function registerEvent($name, $table = null, \Closure $action) {
+		$this->connection->getEventHandler()->registerEvent($name, $table, $action);
+	}
+
+	/**
+	 * Remove event by event-name and/or table
+	 *
+	 * @param string $name
+	 * @param string|null $table
+	 *
+	 * @return void
+	 */
+	public function removeEvent($name, $table = null) {
+		$this->connection->getEventHandler()->removeEvent($name, $table);
+	}
+
+	/**
+	 * Replace key/value array
+	 *
+	 * @param array $data
+	 *
+	 * @throws Exception
+	 * @return array|string
+	 */
+	public function replace($data) {
+		return $this->doInsert($data, 'replace');
+	}
+
+	/**
+	 * Adds new right join statement to the current query.
+	 *
+	 * @param string|Raw|\Closure|array $table
+	 * @param string|Raw|\Closure $key
+	 * @param string|null $operator
+	 * @param string|Raw|\Closure|null $value
+	 *
+	 * @return static
+	 * @throws Exception
+	 */
+	public function rightJoin($table, $key, $operator = null, $value = null) {
+		return $this->join($table, $key, $operator, $value, 'right');
+	}
+
+	/**
+	 * Adds fields to select on the current query (defaults is all).
+	 * You can use key/value array to create alias.
+	 * Sub-queries and raw-objects are also supported.
+	 *
+	 * Example: ['field' => 'alias'] will become `field` AS `alias`
+	 *
+	 * @param string|array $fields,...
+	 *
+	 * @return static
+	 */
+	public function select($fields) {
+		if (is_array($fields) === false) {
+			$fields = func_get_args();
+		}
+
+		$fields = $this->addTablePrefix($fields);
+		$this->addStatement('selects', $fields);
+
+		return $this;
+	}
+
+	/**
+	 * Performs select distinct on the current query.
+	 *
+	 * @param string|Raw|\Closure|array $fields
+	 *
+	 * @return static
+	 */
+	public function selectDistinct($fields) {
+		$this->select($fields);
+		$this->addStatement('distinct', true);
+
+		return $this;
+	}
+
+	/**
+	 * Set connection object
+	 *
+	 * @param Connection $connection
+	 *
+	 * @return static
+	 */
+	public function setConnection(Connection $connection) {
+		$this->connection = $connection;
+
+		return $this;
+	}
+
+	/**
+	 * Add fetch parameters to the PDO-query.
+	 *
+	 * @param mixed $parameters ...
+	 *
+	 * @return static
+	 */
+	public function setFetchMode($parameters = null) {
+		$this->fetchParameters = func_get_args();
+
+		return $this;
+	}
+
+	/**
+	 * Execute statement
+	 *
+	 * @param string $sql
+	 * @param array $bindings
+	 *
+	 * @return array PDOStatement and execution time as float
+	 */
+	public function statement($sql, array $bindings = []) {
+		$start = microtime(true);
+
+		$pdoStatement = $this->pdo->prepare($sql);
+
+		$pdoStatement->execute($bindings);
+
+		return [$pdoStatement, microtime(true) - $start];
+	}
+
+	/**
+	 * Performs new sub-query.
+	 * Call this method when you want to add a new sub-query in your where etc.
+	 *
+	 * @param QueryBuilderHandler $queryBuilder
+	 * @param string|null $alias
+	 *
+	 * @throws Exception
+	 * @return Raw
+	 */
+	public function subQuery(QueryBuilderHandler $queryBuilder, $alias = null) {
+		$sql = '(' . $queryBuilder->getQuery()->getRawSql() . ')';
+		if ($alias !== null) {
+			$sql = $sql . ' AS ' . $this->adapterInstance->wrapSanitizer($alias);
+		}
+
+		return $queryBuilder->raw($sql);
+	}
+
+	/**
+	 * Sets the table that the query is using
+	 *
+	 * @param string|array $tables Single table or multiple tables as an array or as multiple parameters
+	 *
+	 * @throws Exception
+	 * @return static
+	 *
+	 * ```
+	 * Examples:
+	 *  - basic usage
+	 * ->table('table_one')
+	 * ->table(['table_one'])
+	 *
+	 *  - with aliasing
+	 * ->table(['table_one' => 'one'])
+	 * ->table($qb->raw('table_one as one'))
+	 * ```
+	 */
+	public function table($tables) {
+		$tTables = [];
+
+		if (is_array($tables) === false) {
+			// Because a single table is converted to an array anyways, this makes sense.
+			$tables = \func_get_args();
+		}
+
+		$instance = new static($this->connection);
+
+		foreach ($tables as $key => $value) {
+			if (is_string($key)) {
+				$instance->alias($value, $key);
+				$tTables[] = $key;
+			} else {
+				$tTables[] = $value;
+			}
+		}
+
+		$tTables = $this->addTablePrefix($tTables, false);
+		$instance->addStatement('tables', $tTables);
+
+		return $instance;
+	}
+
+	/**
+	 * Performs the transaction
+	 *
+	 * @param \Closure $callback
+	 *
+	 * @throws Exception
+	 * @return Transaction
+	 */
+	public function transaction(\Closure $callback) {
+		/**
+		 * Get the Transaction class
+		 *
+		 * @var \Pecee\Pixie\QueryBuilder\Transaction $queryTransaction
+		 */
+		$queryTransaction             = new Transaction($this->connection);
+		$queryTransaction->statements = $this->statements;
+
+		try {
+			// Begin the PDO transaction
+			if ($this->pdo->inTransaction() === false) {
+				$this->pdo->beginTransaction();
+			}
+
+			// Call closure - this callback will return TransactionHaltException if user has already committed the transaction
+			$callback($queryTransaction);
+
+			// If no errors have been thrown or the transaction wasn't completed within the closure, commit the changes
+			$this->pdo->commit();
+
+		} catch (TransactionHaltException $e) {
+
+			// Commit or rollback behavior has been triggered in the closure
+			return $queryTransaction;
+
+		} catch (\Exception $e) {
+
+			// Something went wrong. Rollback and throw Exception
+			if ($this->pdo->inTransaction() === true) {
+				$this->pdo->rollBack();
+			}
+
+			throw new Exception($e->getMessage());
+		}
+
+		return $queryTransaction;
+	}
+
+	/**
+	 * Update key/value array
+	 *
+	 * @param array $data
+	 *
+	 * @throws Exception
+	 * @return \PDOStatement
+	 */
+	public function update($data) {
+		/**
+		 * @var $response \PDOStatement
+		 */
+		$queryObject = $this->getQuery('update', $data);
+
+		$this->fireEvents(EventHandler::EVENT_BEFORE_UPDATE, $queryObject);
+
+		list($response, $executionTime) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
+		$this->fireEvents(EventHandler::EVENT_AFTER_UPDATE, $queryObject, $executionTime);
+
+		return $response;
+	}
+
+	/**
+	 * Update or insert key/value array
+	 *
+	 * @param array $data
+	 *
+	 * @return array|\PDOStatement|string
+	 * @throws Exception
+	 */
+	public function updateOrInsert($data) {
+		if ($this->first() !== null) {
+			return $this->update($data);
+		}
+
+		return $this->insert($data);
+	}
+
+	/**
+	 * Adds WHERE statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 * @param string|null $operator
+	 * @param mixed|Raw|\Closure|null $value
+	 *
+	 * @return static
+	 */
+	public function where($key, $operator = null, $value = null) {
+		// If two params are given then assume operator is =
+		if (func_num_args() === 2) {
+			$value    = $operator;
+			$operator = '=';
+		}
+
+		if (is_bool($value) === true) {
+			$value = (int)$value;
+		}
+
+		return $this->whereHandler($key, $operator, $value);
+	}
+
+	/**
+	 * Adds WHERE BETWEEN statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 * @param string|integer|float $valueFrom
+	 * @param string|integer|float $valueTo
+	 *
+	 * @return static
+	 */
+	public function whereBetween($key, $valueFrom, $valueTo) {
+		return $this->whereHandler($key, 'BETWEEN', [$valueFrom, $valueTo]);
+	}
+
+	/**
+	 * Handles where statements
+	 *
+	 * @param string|Raw|\Closure $key
+	 * @param string|null $operator
+	 * @param string|Raw|\Closure|null $value
+	 * @param string $joiner
+	 *
+	 * @return static
+	 */
+	protected function whereHandler($key, $operator = null, $value = null, $joiner = 'AND') {
+		$key                          = $this->addTablePrefix($key);
+		$this->statements['wheres'][] = compact('key', 'operator', 'value', 'joiner');
+
+		return $this;
+	}
+
+	/**
+	 * Adds WHERE IN statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 * @param array|Raw|\Closure $values
+	 *
+	 * @return static
+	 */
+	public function whereIn($key, $values) {
+		return $this->whereHandler($key, 'IN', $values);
+	}
+
+	/**
+	 * Adds WHERE NOT statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 * @param string|array|Raw|\Closure|null $operator
+	 * @param mixed|Raw|\Closure|null $value
+	 *
+	 * @return static
+	 */
+	public function whereNot($key, $operator = null, $value = null) {
+		// If two params are given then assume operator is =
+		if (func_num_args() === 2) {
+			$value    = $operator;
+			$operator = '=';
+		}
+
+		return $this->whereHandler($key, $operator, $value, 'AND NOT');
+	}
+
+	/**
+	 * Adds OR WHERE NOT IN statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 * @param array|Raw|\Closure $values
+	 *
+	 * @return static
+	 */
+	public function whereNotIn($key, $values) {
+		return $this->whereHandler($key, 'NOT IN', $values);
+	}
+
+	/**
+	 * Adds WHERE NOT NULL statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 *
+	 * @return static
+	 */
+	public function whereNotNull($key) {
+		return $this->whereNullHandler($key, 'NOT');
+	}
+
+	/**
+	 * Adds WHERE NULL statement to the current query.
+	 *
+	 * @param string|Raw|\Closure $key
+	 *
+	 * @return static
+	 */
+	public function whereNull($key) {
+		return $this->whereNullHandler($key);
+	}
+
+	/**
+	 * Handles WHERE NULL statements.
+	 *
+	 * @param string|Raw|\Closure $key
+	 * @param string $prefix
+	 * @param string $operator
+	 *
+	 * @return static
+	 */
+	protected function whereNullHandler($key, $prefix = '', $operator = '') {
+		$key    = $this->adapterInstance->wrapSanitizer($this->addTablePrefix($key));
+		$prefix = ($prefix !== '') ? $prefix . ' ' : $prefix;
+
+		return $this->{$operator . 'Where'}($this->raw("$key IS {$prefix}NULL"));
+	}
 
 }

--- a/src/Pecee/Pixie/QueryBuilder/QueryObject.php
+++ b/src/Pecee/Pixie/QueryBuilder/QueryObject.php
@@ -2,104 +2,101 @@
 
 namespace Pecee\Pixie\QueryBuilder;
 
+use PDO;
+
 /**
  * Class QueryObject
  *
  * @package Pecee\Pixie\QueryBuilder
  */
-class QueryObject
-{
+class QueryObject {
 
-    /**
-     * @var string
-     */
-    protected $sql;
+	/**
+	 * @var string
+	 */
+	protected $sql;
 
-    /**
-     * @var array
-     */
-    protected $bindings = [];
+	/**
+	 * @var array
+	 */
+	protected $bindings = [];
 
-    /**
-     * @var \PDO
-     */
-    protected $pdo;
+	/**
+	 * @var PDO
+	 */
+	protected $pdo;
 
-    /**
-     * QueryObject constructor.
-     *
-     * @param string $sql
-     * @param array $bindings
-     * @param \PDO $pdo
-     */
-    public function __construct($sql, array $bindings, \PDO $pdo)
-    {
-        $this->sql = (string)$sql;
-        $this->bindings = $bindings;
-        $this->pdo = $pdo;
-    }
+	/**
+	 * QueryObject constructor.
+	 *
+	 * @param string $sql
+	 * @param array $bindings
+	 * @param PDO $pdo
+	 */
+	public function __construct($sql, array $bindings, PDO $pdo) {
+		$this->sql      = (string)$sql;
+		$this->bindings = $bindings;
+		$this->pdo      = $pdo;
+	}
 
-    /**
-     * @return array
-     */
-    public function getBindings()
-    {
-        return $this->bindings;
-    }
+	/**
+	 * @return array
+	 */
+	public function getBindings() {
+		return $this->bindings;
+	}
 
-    /**
-     * Get the raw/bound sql
-     * @return string
-     */
-    public function getRawSql()
-    {
-        return $this->interpolateQuery($this->sql, $this->bindings);
-    }
+	/**
+	 * Get the raw/bound sql
+	 * @return string
+	 */
+	public function getRawSql() {
+		return $this->interpolateQuery($this->sql, $this->bindings);
+	}
 
-    /**
-     * @return string
-     */
-    public function getSql()
-    {
-        return $this->sql;
-    }
+	/**
+	 * @return string
+	 */
+	public function getSql() {
+		return $this->sql;
+	}
 
-    /**
-     * Replaces any parameter placeholders in a query with the value of that
-     * parameter. Useful for debugging. Assumes anonymous parameters from
-     * $params are are in the same order as specified in $query
-     *
-     * Reference: http://stackoverflow.com/a/1376838/656489
-     *
-     * @param string $query The sql query with parameter placeholders
-     * @param array $params The array of substitution parameters
-     * @return string The interpolated query
-     */
-    protected function interpolateQuery($query, $params)
-    {
-        $keys = [];
-        $values = $params;
+	/**
+	 * Replaces any parameter placeholders in a query with the value of that
+	 * parameter. Useful for debugging. Assumes anonymous parameters from
+	 * $params are are in the same order as specified in $query
+	 *
+	 * Reference: http://stackoverflow.com/a/1376838/656489
+	 *
+	 * @param string $query The sql query with parameter placeholders
+	 * @param array $params The array of substitution parameters
+	 *
+	 * @return string The interpolated query
+	 */
+	protected function interpolateQuery($query, $params) {
+		$keys   = [];
+		$values = $params;
 
-        // build a regular expression for each parameter
-        foreach ($params as $key => $value) {
-            $keys[] = '/' . (is_string($key) ? ':' . $key : '[?]') . '/';
+		// build a regular expression for each parameter
+		foreach ($params as $key => $value) {
+			$keys[] = '/' . (is_string($key) ? ':' . $key : '[?]') . '/';
 
-            if (is_string($value) === true) {
-                $values[$key] = $this->pdo->quote($value);
-                continue;
-            }
+			if (is_string($value) === true) {
+				$values[ $key ] = $this->pdo->quote($value);
+				continue;
+			}
 
-            if (is_array($value) === true) {
-                $values[$key] = $this->pdo->quote(implode(',', $value));
-                continue;
-            }
+			if (is_array($value) === true) {
+				$values[ $key ] = $this->pdo->quote(implode(',', $value));
+				continue;
+			}
 
-            if ($value === null) {
-                $values[$key] = 'NULL';
-                continue;
-            }
-        }
+			if ($value === null) {
+				$values[ $key ] = 'NULL';
+				continue;
+			}
+		}
 
-        return preg_replace($keys, $values, $query, 1, $count);
-    }
+		return preg_replace($keys, $values, $query, 1, $count);
+	}
 }

--- a/src/Pecee/Pixie/QueryBuilder/Raw.php
+++ b/src/Pecee/Pixie/QueryBuilder/Raw.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Pecee\Pixie\QueryBuilder;
 
 /**
@@ -6,43 +7,40 @@ namespace Pecee\Pixie\QueryBuilder;
  *
  * @package Pecee\Pixie\QueryBuilder
  */
-class Raw
-{
+class Raw {
 
-    /**
-     * @var string
-     */
-    protected $value;
+	/**
+	 * @var string
+	 */
+	protected $value;
 
-    /**
-     * @var array
-     */
-    protected $bindings;
+	/**
+	 * @var array
+	 */
+	protected $bindings;
 
-    /**
-     * Raw constructor.
-     * @param string $value
-     * @param array|string $bindings
-     */
-    public function __construct($value, array $bindings = [])
-    {
-        $this->value = (string)$value;
-        $this->bindings = (array)$bindings;
-    }
+	/**
+	 * Raw constructor.
+	 *
+	 * @param string $value
+	 * @param array|string $bindings
+	 */
+	public function __construct($value, array $bindings = []) {
+		$this->value    = (string)$value;
+		$this->bindings = (array)$bindings;
+	}
 
-    /**
-     * @return array
-     */
-    public function getBindings()
-    {
-        return $this->bindings;
-    }
+	/**
+	 * @return array
+	 */
+	public function getBindings() {
+		return $this->bindings;
+	}
 
-    /**
-     * @return string
-     */
-    public function __toString()
-    {
-        return (string)$this->value;
-    }
+	/**
+	 * @return string
+	 */
+	public function __toString() {
+		return (string)$this->value;
+	}
 }

--- a/src/Pecee/Pixie/QueryBuilder/Transaction.php
+++ b/src/Pecee/Pixie/QueryBuilder/Transaction.php
@@ -10,23 +10,61 @@ namespace Pecee\Pixie\QueryBuilder;
 class Transaction extends QueryBuilderHandler
 {
 
+    protected $transactionStatement;
+
     /**
-     * Commit the database changes
-     * @throws TransactionHaltException
+     * @param \Closure $callback
+     *
+     * @return static
+     */
+    public function transaction(\Closure $callback)
+    {
+        $callback($this);
+
+        return $this;
+    }
+
+    /**
+     * Commit transaction
+     *
+     * @throws \PDOException|TransactionHaltException
      */
     public function commit()
     {
         $this->pdo->commit();
-        throw new TransactionHaltException('Commit');
+        throw new TransactionHaltException('Commit triggered transaction-halt.');
     }
 
     /**
-     * Rollback the database changes
-     * @throws TransactionHaltException
+     * RollBack transaction
+     *
+     * @throws \PDOException|TransactionHaltException
      */
-    public function rollback()
+    public function rollBack()
     {
         $this->pdo->rollBack();
-        throw new TransactionHaltException('Rollback');
+        throw new TransactionHaltException('Rollback triggered transaction-halt.');
     }
+
+    /**
+     * Execute statement
+     *
+     * @param string $sql
+     * @param array $bindings
+     *
+     * @return array PDOStatement and execution time as float
+     */
+    public function statement($sql, array $bindings = [])
+    {
+        $start = microtime(true);
+
+        if ($this->transactionStatement === null && $this->pdo->inTransaction() === true) {
+            $this->transactionStatement = $this->pdo->prepare($sql);
+        }
+
+        $this->transactionStatement->execute($bindings);
+
+        return [$this->transactionStatement, microtime(true) - $start];
+    }
+
 }

--- a/src/Pecee/Pixie/QueryBuilder/Transaction.php
+++ b/src/Pecee/Pixie/QueryBuilder/Transaction.php
@@ -7,64 +7,59 @@ namespace Pecee\Pixie\QueryBuilder;
  *
  * @package Pecee\Pixie\QueryBuilder
  */
-class Transaction extends QueryBuilderHandler
-{
+class Transaction extends QueryBuilderHandler {
 
-    protected $transactionStatement;
+	protected $transactionStatement;
 
-    /**
-     * @param \Closure $callback
-     *
-     * @return static
-     */
-    public function transaction(\Closure $callback)
-    {
-        $callback($this);
+	/**
+	 * @param \Closure $callback
+	 *
+	 * @return static
+	 */
+	public function transaction(\Closure $callback) {
+		$callback($this);
 
-        return $this;
-    }
+		return $this;
+	}
 
-    /**
-     * Commit transaction
-     *
-     * @throws \PDOException|TransactionHaltException
-     */
-    public function commit()
-    {
-        $this->pdo->commit();
-        throw new TransactionHaltException('Commit triggered transaction-halt.');
-    }
+	/**
+	 * Commit transaction
+	 *
+	 * @throws \PDOException|TransactionHaltException
+	 */
+	public function commit() {
+		$this->pdo->commit();
+		throw new TransactionHaltException('Commit triggered transaction-halt.');
+	}
 
-    /**
-     * RollBack transaction
-     *
-     * @throws \PDOException|TransactionHaltException
-     */
-    public function rollBack()
-    {
-        $this->pdo->rollBack();
-        throw new TransactionHaltException('Rollback triggered transaction-halt.');
-    }
+	/**
+	 * RollBack transaction
+	 *
+	 * @throws \PDOException|TransactionHaltException
+	 */
+	public function rollBack() {
+		$this->pdo->rollBack();
+		throw new TransactionHaltException('Rollback triggered transaction-halt.');
+	}
 
-    /**
-     * Execute statement
-     *
-     * @param string $sql
-     * @param array $bindings
-     *
-     * @return array PDOStatement and execution time as float
-     */
-    public function statement($sql, array $bindings = [])
-    {
-        $start = microtime(true);
+	/**
+	 * Execute statement
+	 *
+	 * @param string $sql
+	 * @param array $bindings
+	 *
+	 * @return array PDOStatement and execution time as float
+	 */
+	public function statement($sql, array $bindings = []) {
+		$start = microtime(true);
 
-        if ($this->transactionStatement === null && $this->pdo->inTransaction() === true) {
-            $this->transactionStatement = $this->pdo->prepare($sql);
-        }
+		if ($this->transactionStatement === null && $this->pdo->inTransaction() === true) {
+			$this->transactionStatement = $this->pdo->prepare($sql);
+		}
 
-        $this->transactionStatement->execute($bindings);
+		$this->transactionStatement->execute($bindings);
 
-        return [$this->transactionStatement, microtime(true) - $start];
-    }
+		return [$this->transactionStatement, microtime(true) - $start];
+	}
 
 }

--- a/src/Pecee/Pixie/QueryBuilder/TransactionHaltException.php
+++ b/src/Pecee/Pixie/QueryBuilder/TransactionHaltException.php
@@ -7,6 +7,5 @@ namespace Pecee\Pixie\QueryBuilder;
  *
  * @package Pecee\Pixie\QueryBuilder
  */
-class TransactionHaltException extends \Exception
-{
+class TransactionHaltException extends \Exception {
 }

--- a/tests/Pecee/Pixie/ConnectionTest.php
+++ b/tests/Pecee/Pixie/ConnectionTest.php
@@ -1,8 +1,8 @@
 <?php namespace Pecee\Pixie;
 
 use Mockery as m;
+use Pecee\Pixie\ConnectionAdapters\IConnectionAdapter;
 use Pecee\Pixie\ConnectionAdapters\Mysql;
-use Pecee\Pixie\QueryBuilder\QueryBuilderHandler;
 
 class ConnectionTest extends TestCase
 {
@@ -16,15 +16,14 @@ class ConnectionTest extends TestCase
         $this->mysqlConnectionMock = m::mock(Mysql::class);
         $this->mysqlConnectionMock->shouldReceive('connect')->andReturn($this->mockPdo);
 
-        $this->container->setInstance('\Pecee\Pixie\ConnectionAdapters\Mysqlmock', $this->mysqlConnectionMock);
-        $this->connection = new Connection('mysqlmock', array('prefix' => 'cb_'), $this->container);
+        $this->connection = new Connection($this->mysqlConnectionMock, array('prefix' => 'cb_'));
     }
 
     public function testConnection()
     {
         $this->assertEquals($this->mockPdo, $this->connection->getPdoInstance());
-        $this->assertInstanceOf('\PDO', $this->connection->getPdoInstance());
-        $this->assertEquals('mysqlmock', $this->connection->getAdapter());
+        $this->assertInstanceOf(\PDO::class, $this->connection->getPdoInstance());
+        $this->assertInstanceOf(IConnectionAdapter::class, $this->connection->getAdapter());
         $this->assertEquals(array('prefix' => 'cb_'), $this->connection->getAdapterConfig());
     }
 }

--- a/tests/Pecee/Pixie/ConnectionTest.php
+++ b/tests/Pecee/Pixie/ConnectionTest.php
@@ -4,26 +4,23 @@ use Mockery as m;
 use Pecee\Pixie\ConnectionAdapters\IConnectionAdapter;
 use Pecee\Pixie\ConnectionAdapters\Mysql;
 
-class ConnectionTest extends TestCase
-{
-    private $mysqlConnectionMock;
-    private $connection;
+class ConnectionTest extends TestCase {
+	private $mysqlConnectionMock;
+	private $connection;
 
-    public function setUp()
-    {
-        parent::setUp();
+	public function setUp() {
+		parent::setUp();
 
-        $this->mysqlConnectionMock = m::mock(Mysql::class);
-        $this->mysqlConnectionMock->shouldReceive('connect')->andReturn($this->mockPdo);
+		$this->mysqlConnectionMock = m::mock(Mysql::class);
+		$this->mysqlConnectionMock->shouldReceive('connect')->andReturn($this->mockPdo);
 
-        $this->connection = new Connection($this->mysqlConnectionMock, array('prefix' => 'cb_'));
-    }
+		$this->connection = new Connection($this->mysqlConnectionMock, array('prefix' => 'cb_'));
+	}
 
-    public function testConnection()
-    {
-        $this->assertEquals($this->mockPdo, $this->connection->getPdoInstance());
-        $this->assertInstanceOf(\PDO::class, $this->connection->getPdoInstance());
-        $this->assertInstanceOf(IConnectionAdapter::class, $this->connection->getAdapter());
-        $this->assertEquals(array('prefix' => 'cb_'), $this->connection->getAdapterConfig());
-    }
+	public function testConnection() {
+		$this->assertEquals($this->mockPdo, $this->connection->getPdoInstance());
+		$this->assertInstanceOf(\PDO::class, $this->connection->getPdoInstance());
+		$this->assertInstanceOf(IConnectionAdapter::class, $this->connection->getAdapter());
+		$this->assertEquals(array('prefix' => 'cb_'), $this->connection->getAdapterConfig());
+	}
 }

--- a/tests/Pecee/Pixie/NoTableSubQueryTest.php
+++ b/tests/Pecee/Pixie/NoTableSubQueryTest.php
@@ -24,9 +24,12 @@ class NoTableSubQueryTest extends TestCase
         $subQuery1 = $this->builder->table('mail')->select($this->builder->raw('COUNT(*)'));
         $subQuery2 = $this->builder->table('event_message')->select($this->builder->raw('COUNT(*)'));
 
-        $count = $this->builder->select($this->builder->subQuery($subQuery1, 'row1'), $this->builder->subQuery($subQuery2, 'row2'))->first();
+        $count = $this->builder->select($this->builder->subQuery($subQuery1, 'row1'),
+            $this->builder->subQuery($subQuery2, 'row2'))->first()
+        ;
 
-        $this->assertEquals('SELECT (SELECT COUNT(*) FROM `cb_mail`) AS `row1`, (SELECT COUNT(*) FROM `cb_event_message`) AS `row2` LIMIT 1', $count);
+        $this->assertEquals('SELECT (SELECT COUNT(*) FROM `cb_mail`) AS `row1`, (SELECT COUNT(*) FROM `cb_event_message`) AS `row2` LIMIT 1',
+            $count);
 
     }
 

--- a/tests/Pecee/Pixie/NoTableSubQueryTest.php
+++ b/tests/Pecee/Pixie/NoTableSubQueryTest.php
@@ -1,36 +1,32 @@
 <?php
+
 namespace Pecee\Pixie;
 
-use Mockery as m;
 use Pecee\Pixie\QueryBuilder\QueryBuilderHandler;
 
-class NoTableSubQueryTest extends TestCase
-{
-    /**
-     * @var QueryBuilderHandler
-     */
-    protected $builder;
+class NoTableSubQueryTest extends TestCase {
+	/**
+	 * @var QueryBuilderHandler
+	 */
+	protected $builder;
 
-    public function setUp()
-    {
-        parent::setUp();
+	public function setUp() {
+		parent::setUp();
 
-        $this->builder = new QueryBuilderHandler($this->mockConnection);
-    }
+		$this->builder = new QueryBuilderHandler($this->mockConnection);
+	}
 
-    public function testRawQuery()
-    {
+	public function testRawQuery() {
 
-        $subQuery1 = $this->builder->table('mail')->select($this->builder->raw('COUNT(*)'));
-        $subQuery2 = $this->builder->table('event_message')->select($this->builder->raw('COUNT(*)'));
+		$subQuery1 = $this->builder->table('mail')->select($this->builder->raw('COUNT(*)'));
+		$subQuery2 = $this->builder->table('event_message')->select($this->builder->raw('COUNT(*)'));
 
-        $count = $this->builder->select($this->builder->subQuery($subQuery1, 'row1'),
-            $this->builder->subQuery($subQuery2, 'row2'))->first()
-        ;
+		$count = $this->builder->select($this->builder->subQuery($subQuery1, 'row1'),
+			$this->builder->subQuery($subQuery2, 'row2'))->first();
 
-        $this->assertEquals('SELECT (SELECT COUNT(*) FROM `cb_mail`) AS `row1`, (SELECT COUNT(*) FROM `cb_event_message`) AS `row2` LIMIT 1',
-            $count);
+		$this->assertEquals('SELECT (SELECT COUNT(*) FROM `cb_mail`) AS `row1`, (SELECT COUNT(*) FROM `cb_event_message`) AS `row2` LIMIT 1',
+			$count);
 
-    }
+	}
 
 }

--- a/tests/Pecee/Pixie/QueryBuilderBehaviorTest.php
+++ b/tests/Pecee/Pixie/QueryBuilderBehaviorTest.php
@@ -1,363 +1,336 @@
 <?php
+
 namespace Pecee\Pixie;
 
-use Mockery as m;
 use Pecee\Pixie\QueryBuilder\QueryBuilderHandler;
 
-class QueryBuilderTest extends TestCase
-{
-    /**
-     * @var QueryBuilderHandler
-     */
-    private $builder;
+class QueryBuilderTest extends TestCase {
+	/**
+	 * @var QueryBuilderHandler
+	 */
+	private $builder;
 
-    public function setUp()
-    {
-        parent::setUp();
+	public function setUp() {
+		parent::setUp();
 
-        $this->builder = new QueryBuilder\QueryBuilderHandler($this->mockConnection);
-    }
+		$this->builder = new QueryBuilder\QueryBuilderHandler($this->mockConnection);
+	}
 
-    /**
-     * Test alias
-     */
-    public function testAlias()
-    {
-        $query = $this->builder
-            ->table(['table1'])
-            ->alias('t1')
-            ->join('table2', 'table2.person_id', '=', 'foo2.id')
-        ;
+	/**
+	 * Test alias
+	 */
+	public function testAlias() {
+		$query = $this->builder
+			->table(['table1'])
+			->alias('t1')
+			->join('table2', 'table2.person_id', '=', 'foo2.id');
 
-        $this->assertEquals('SELECT * FROM `cb_table1` AS `t1` INNER JOIN `cb_table2` ON `cb_table2`.`person_id` = `cb_foo2`.`id`',
-            $query->getQuery()->getRawSql());
-    }
+		$this->assertEquals('SELECT * FROM `cb_table1` AS `t1` INNER JOIN `cb_table2` ON `cb_table2`.`person_id` = `cb_foo2`.`id`',
+			$query->getQuery()->getRawSql());
+	}
 
-    /**
-     * Test delete
-     */
-    public function testDeleteQuery()
-    {
-        $this->builder = new QueryBuilder\QueryBuilderHandler($this->mockConnection);
+	/**
+	 * Test delete
+	 */
+	public function testDeleteQuery() {
+		$this->builder = new QueryBuilder\QueryBuilderHandler($this->mockConnection);
 
-        $builder = $this->builder->table('my_table')->where('value', '=', 'Amrin');
+		$builder = $this->builder->table('my_table')->where('value', '=', 'Amrin');
 
-        $this->assertEquals("DELETE FROM `cb_my_table` WHERE `value` = 'Amrin'"
-            , $builder->getQuery('delete')->getRawSql());
-    }
+		$this->assertEquals("DELETE FROM `cb_my_table` WHERE `value` = 'Amrin'"
+			, $builder->getQuery('delete')->getRawSql());
+	}
 
-    public function testEventPropagation()
-    {
-        $builder = $this->builder;
+	public function testEventPropagation() {
+		$builder = $this->builder;
 
-        $events = [
-            'before-insert',
-            'after-insert',
-            'before-select',
-            'after-select',
-            'before-update',
-            'after-update',
-            'before-delete',
-            'after-delete',
-        ];
+		$events = [
+			'before-insert',
+			'after-insert',
+			'before-select',
+			'after-select',
+			'before-update',
+			'after-update',
+			'before-delete',
+			'after-delete',
+		];
 
-        $triggeredEvents = [];
+		$triggeredEvents = [];
 
-        foreach ($events as $event) {
-            $builder->registerEvent($event, ':any', function ($qb) use (&$triggeredEvents, $event) {
-                $triggeredEvents[] = $event;
-            });
-        }
+		foreach ($events as $event) {
+			$builder->registerEvent($event, ':any', function ($qb) use (&$triggeredEvents, $event) {
+				$triggeredEvents[] = $event;
+			});
+		}
 
-        $builder->table('foo')->insert(['bar' => 'baz']);
-        $builder->from('foo')->select('bar')->get();
-        $builder->table('foo')->update(['bar' => 'baz']);
-        $builder->from('foo')->delete();
+		$builder->table('foo')->insert(['bar' => 'baz']);
+		$builder->from('foo')->select('bar')->get();
+		$builder->table('foo')->update(['bar' => 'baz']);
+		$builder->from('foo')->delete();
 
-        $this->assertEquals($triggeredEvents, $events);
-    }
+		$this->assertEquals($triggeredEvents, $events);
+	}
 
-    public function testInsertIgnoreQuery()
-    {
-        $builder = $this->builder->from('my_table');
-        $data    = [
-            'key'   => 'Name',
-            'value' => 'Sana',
-        ];
+	public function testInsertIgnoreQuery() {
+		$builder = $this->builder->from('my_table');
+		$data    = [
+			'key'   => 'Name',
+			'value' => 'Sana',
+		];
 
-        $this->assertEquals("INSERT IGNORE INTO `cb_my_table` (`key`,`value`) VALUES ('Name','Sana')"
-            , $builder->getQuery('insertignore', $data)->getRawSql());
-    }
+		$this->assertEquals("INSERT IGNORE INTO `cb_my_table` (`key`,`value`) VALUES ('Name','Sana')"
+			, $builder->getQuery('insertignore', $data)->getRawSql());
+	}
 
-    public function testInsertOnDuplicateKeyUpdateQuery()
-    {
-        $builder    = $this->builder;
-        $data       = [
-            'name'    => 'Sana',
-            'counter' => 1,
-        ];
-        $dataUpdate = [
-            'name'    => 'Sana',
-            'counter' => 2,
-        ];
-        $builder->from('my_table')->onDuplicateKeyUpdate($dataUpdate);
-        $this->assertEquals("INSERT INTO `cb_my_table` (`name`,`counter`) VALUES ('Sana',1) ON DUPLICATE KEY UPDATE `name`='Sana',`counter`=2"
-            , $builder->getQuery('insert', $data)->getRawSql());
-    }
+	public function testInsertOnDuplicateKeyUpdateQuery() {
+		$builder    = $this->builder;
+		$data       = [
+			'name'    => 'Sana',
+			'counter' => 1,
+		];
+		$dataUpdate = [
+			'name'    => 'Sana',
+			'counter' => 2,
+		];
+		$builder->from('my_table')->onDuplicateKeyUpdate($dataUpdate);
+		$this->assertEquals("INSERT INTO `cb_my_table` (`name`,`counter`) VALUES ('Sana',1) ON DUPLICATE KEY UPDATE `name`='Sana',`counter`=2"
+			, $builder->getQuery('insert', $data)->getRawSql());
+	}
 
-    public function testInsertQuery()
-    {
-        $builder = $this->builder->from('my_table');
-        $data    = [
-            'key'   => 'Name',
-            'value' => 'Sana',
-        ];
+	public function testInsertQuery() {
+		$builder = $this->builder->from('my_table');
+		$data    = [
+			'key'   => 'Name',
+			'value' => 'Sana',
+		];
 
-        $this->assertEquals("INSERT INTO `cb_my_table` (`key`,`value`) VALUES ('Name','Sana')"
-            , $builder->getQuery('insert', $data)->getRawSql());
-    }
+		$this->assertEquals("INSERT INTO `cb_my_table` (`key`,`value`) VALUES ('Name','Sana')"
+			, $builder->getQuery('insert', $data)->getRawSql());
+	}
 
-    public function testIsPossibleToUseSubqueryInWhereClause()
-    {
-        $sub   = clone $this->builder;
-        $query = $this->builder->from('my_table')->whereIn('foo', $this->builder->subQuery(
-            $sub->from('some_table')->select('foo')->where('id', 1)
-        ))
-        ;
-        $this->assertEquals(
-            "SELECT * FROM `cb_my_table` WHERE `foo` IN (SELECT `foo` FROM `cb_some_table` WHERE `id` = 1)",
-            $query->getQuery()->getRawSql()
-        );
-    }
+	public function testIsPossibleToUseSubqueryInWhereClause() {
+		$sub   = clone $this->builder;
+		$query = $this->builder->from('my_table')->whereIn('foo', $this->builder->subQuery(
+			$sub->from('some_table')->select('foo')->where('id', 1)
+		));
+		$this->assertEquals(
+			"SELECT * FROM `cb_my_table` WHERE `foo` IN (SELECT `foo` FROM `cb_some_table` WHERE `id` = 1)",
+			$query->getQuery()->getRawSql()
+		);
+	}
 
-    public function testIsPossibleToUseSubqueryInWhereNotClause()
-    {
-        $sub   = clone $this->builder;
-        $query = $this->builder->from('my_table')->whereNotIn('foo', $this->builder->subQuery(
-            $sub->from('some_table')->select('foo')->where('id', 1)
-        ))
-        ;
-        $this->assertEquals(
-            "SELECT * FROM `cb_my_table` WHERE `foo` NOT IN (SELECT `foo` FROM `cb_some_table` WHERE `id` = 1)",
-            $query->getQuery()->getRawSql()
-        );
-    }
+	public function testIsPossibleToUseSubqueryInWhereNotClause() {
+		$sub   = clone $this->builder;
+		$query = $this->builder->from('my_table')->whereNotIn('foo', $this->builder->subQuery(
+			$sub->from('some_table')->select('foo')->where('id', 1)
+		));
+		$this->assertEquals(
+			"SELECT * FROM `cb_my_table` WHERE `foo` NOT IN (SELECT `foo` FROM `cb_some_table` WHERE `id` = 1)",
+			$query->getQuery()->getRawSql()
+		);
+	}
 
-    public function testOrderByFlexibility()
-    {
-        $query = $this->builder
-            ->from('t')
-            ->orderBy('foo', 'DESC')
-            ->orderBy(['bar', 'baz' => 'ASC', $this->builder->raw('raw1')], 'DESC')
-            ->orderBy($this->builder->raw('raw2'), 'DESC')
-        ;
+	public function testOrderByFlexibility() {
+		$query = $this->builder
+			->from('t')
+			->orderBy('foo', 'DESC')
+			->orderBy(['bar', 'baz' => 'ASC', $this->builder->raw('raw1')], 'DESC')
+			->orderBy($this->builder->raw('raw2'), 'DESC');
 
-        $this->assertEquals(
-            'SELECT * FROM `cb_t` ORDER BY `foo` DESC, `bar` DESC, `baz` ASC, raw1 DESC, raw2 DESC',
-            $query->getQuery()->getRawSql(),
-            'ORDER BY is flexible enough!'
-        );
-    }
+		$this->assertEquals(
+			'SELECT * FROM `cb_t` ORDER BY `foo` DESC, `bar` DESC, `baz` ASC, raw1 DESC, raw2 DESC',
+			$query->getQuery()->getRawSql(),
+			'ORDER BY is flexible enough!'
+		);
+	}
 
-    public function testRawStatementsWithinCriteria()
-    {
-        $query = $this->builder->from('my_table')
-                               ->where('simple', 'criteria')
-                               ->where($this->builder->raw('RAW'))
-                               ->where($this->builder->raw('PARAMETERIZED_ONE(?)', 'foo'))
-                               ->where($this->builder->raw('PARAMETERIZED_SEVERAL(?, ?, ?)', [1, '2', 'foo']))
-        ;
+	public function testRawStatementsWithinCriteria() {
+		$query = $this->builder->from('my_table')
+		                       ->where('simple', 'criteria')
+		                       ->where($this->builder->raw('RAW'))
+		                       ->where($this->builder->raw('PARAMETERIZED_ONE(?)', 'foo'))
+		                       ->where($this->builder->raw('PARAMETERIZED_SEVERAL(?, ?, ?)', [1, '2', 'foo']));
 
-        $this->assertEquals(
-            "SELECT * FROM `cb_my_table` WHERE `simple` = 'criteria' AND RAW AND PARAMETERIZED_ONE('foo') AND PARAMETERIZED_SEVERAL(1, '2', 'foo')",
-            $query->getQuery()->getRawSql()
-        );
-    }
+		$this->assertEquals(
+			"SELECT * FROM `cb_my_table` WHERE `simple` = 'criteria' AND RAW AND PARAMETERIZED_ONE('foo') AND PARAMETERIZED_SEVERAL(1, '2', 'foo')",
+			$query->getQuery()->getRawSql()
+		);
+	}
 
-    public function testReplaceQuery()
-    {
-        $builder = $this->builder->from('my_table');
-        $data    = [
-            'key'   => 'Name',
-            'value' => 'Sana',
-        ];
+	public function testReplaceQuery() {
+		$builder = $this->builder->from('my_table');
+		$data    = [
+			'key'   => 'Name',
+			'value' => 'Sana',
+		];
 
-        $this->assertEquals("REPLACE INTO `cb_my_table` (`key`,`value`) VALUES ('Name','Sana')"
-            , $builder->getQuery('replace', $data)->getRawSql());
-    }
+		$this->assertEquals("REPLACE INTO `cb_my_table` (`key`,`value`) VALUES ('Name','Sana')"
+			, $builder->getQuery('replace', $data)->getRawSql());
+	}
 
-    public function testSelectAliases()
-    {
-        $query = $this->builder->from('my_table')->select('foo')->select(['bar' => 'baz', 'qux']);
+	public function testSelectAliases() {
+		$query = $this->builder->from('my_table')->select('foo')->select(['bar' => 'baz', 'qux']);
 
-        $this->assertEquals(
-            "SELECT `foo`, `bar` AS `baz`, `qux` FROM `cb_my_table`",
-            $query->getQuery()->getRawSql()
-        );
-    }
+		$this->assertEquals(
+			"SELECT `foo`, `bar` AS `baz`, `qux` FROM `cb_my_table`",
+			$query->getQuery()->getRawSql()
+		);
+	}
 
-    public function testSelectDistinct()
-    {
-        $query = $this->builder->selectDistinct(['name', 'surname'])->from('my_table');
-        $this->assertEquals("SELECT DISTINCT `name`, `surname` FROM `cb_my_table`", $query->getQuery()->getRawSql());
-    }
+	public function testSelectDistinct() {
+		$query = $this->builder->selectDistinct(['name', 'surname'])->from('my_table');
+		$this->assertEquals("SELECT DISTINCT `name`, `surname` FROM `cb_my_table`", $query->getQuery()->getRawSql());
+	}
 
-    public function testSelectDistinctAndSelectCalls()
-    {
-        $query = $this->builder->select('name')->selectDistinct('surname')->select(['birthday', 'address'])->from('my_table');
-        $this->assertEquals("SELECT DISTINCT `name`, `surname`, `birthday`, `address` FROM `cb_my_table`", $query->getQuery()->getRawSql());
-    }
+	public function testSelectDistinctAndSelectCalls() {
+		$query = $this->builder->select('name')->selectDistinct('surname')->select([
+			'birthday',
+			'address'
+		])->from('my_table');
+		$this->assertEquals("SELECT DISTINCT `name`, `surname`, `birthday`, `address` FROM `cb_my_table`", $query->getQuery()->getRawSql());
+	}
 
-    public function testSelectDistinctWithSingleColumn()
-    {
-        $query = $this->builder->selectDistinct('name')->from('my_table');
-        $this->assertEquals("SELECT DISTINCT `name` FROM `cb_my_table`", $query->getQuery()->getRawSql());
-    }
+	public function testSelectDistinctWithSingleColumn() {
+		$query = $this->builder->selectDistinct('name')->from('my_table');
+		$this->assertEquals("SELECT DISTINCT `name` FROM `cb_my_table`", $query->getQuery()->getRawSql());
+	}
 
-    public function testSelectFlexibility()
-    {
-        $query = $this->builder
-            ->select('foo')
-            ->select(['bar', 'baz'])
-            ->select('qux', 'lol', 'wut')
-            ->from('t')
-        ;
-        $this->assertEquals(
-            'SELECT `foo`, `bar`, `baz`, `qux`, `lol`, `wut` FROM `cb_t`',
-            $query->getQuery()->getRawSql(),
-            'SELECT is pretty flexible!'
-        );
-    }
+	public function testSelectFlexibility() {
+		$query = $this->builder
+			->select('foo')
+			->select(['bar', 'baz'])
+			->select('qux', 'lol', 'wut')
+			->from('t');
+		$this->assertEquals(
+			'SELECT `foo`, `bar`, `baz`, `qux`, `lol`, `wut` FROM `cb_t`',
+			$query->getQuery()->getRawSql(),
+			'SELECT is pretty flexible!'
+		);
+	}
 
-    public function testSelectQuery()
-    {
-        $subQuery = $this->builder->table('person_details')->select('details')->where('person_id', '=', 3);
+	public function testSelectQuery() {
+		$subQuery = $this->builder->table('person_details')->select('details')->where('person_id', '=', 3);
 
-        $query = $this->builder->table('my_table')
-                               ->select('my_table.*')
-                               ->select([$this->builder->raw('count(cb_my_table.id) AS `tot`'), $this->builder->subQuery($subQuery, 'pop')])
-                               ->where('value', '=', 'Ifrah')
-                               ->whereNot('my_table.id', -1)
-                               ->orWhereNot('my_table.id', -2)
-                               ->orWhereIn('my_table.id', [1, 2])
-                               ->groupBy(['value', 'my_table.id', 'person_details.id'])
-                               ->orderBy('my_table.id', 'DESC')
-                               ->orderBy('value')
-                               ->having('tot', '<', 2)
-                               ->limit(1)
-                               ->offset(0)
-                               ->join(
-                                   'person_details',
-                                   'person_details.person_id',
-                                   '=',
-                                   'my_table.id'
-                               )
-        ;
+		$query = $this->builder->table('my_table')
+		                       ->select('my_table.*')
+		                       ->select([
+			                       $this->builder->raw('count(cb_my_table.id) AS `tot`'),
+			                       $this->builder->subQuery($subQuery, 'pop')
+		                       ])
+		                       ->where('value', '=', 'Ifrah')
+		                       ->whereNot('my_table.id', - 1)
+		                       ->orWhereNot('my_table.id', - 2)
+		                       ->orWhereIn('my_table.id', [1, 2])
+		                       ->groupBy(['value', 'my_table.id', 'person_details.id'])
+		                       ->orderBy('my_table.id', 'DESC')
+		                       ->orderBy('value')
+		                       ->having('tot', '<', 2)
+		                       ->limit(1)
+		                       ->offset(0)
+		                       ->join(
+			                       'person_details',
+			                       'person_details.person_id',
+			                       '=',
+			                       'my_table.id'
+		                       );
 
-        $nestedQuery = $this->builder->table($this->builder->subQuery($query, 'bb'))->select('*');
-        $this->assertEquals("SELECT * FROM (SELECT `cb_my_table`.*, count(cb_my_table.id) AS `tot`, (SELECT `details` FROM `cb_person_details` WHERE `person_id` = 3) AS `pop` FROM `cb_my_table` INNER JOIN `cb_person_details` ON `cb_person_details`.`person_id` = `cb_my_table`.`id` WHERE `value` = 'Ifrah' AND NOT `cb_my_table`.`id` = -1 OR NOT `cb_my_table`.`id` = -2 OR `cb_my_table`.`id` IN (1, 2) GROUP BY `value`, `cb_my_table`.`id`, `cb_person_details`.`id` HAVING `tot` < 2 ORDER BY `cb_my_table`.`id` DESC, `value` ASC LIMIT 1 OFFSET 0) AS `bb`"
-            , $nestedQuery->getQuery()->getRawSql());
-    }
+		$nestedQuery = $this->builder->table($this->builder->subQuery($query, 'bb'))->select('*');
+		$this->assertEquals("SELECT * FROM (SELECT `cb_my_table`.*, count(cb_my_table.id) AS `tot`, (SELECT `details` FROM `cb_person_details` WHERE `person_id` = 3) AS `pop` FROM `cb_my_table` INNER JOIN `cb_person_details` ON `cb_person_details`.`person_id` = `cb_my_table`.`id` WHERE `value` = 'Ifrah' AND NOT `cb_my_table`.`id` = -1 OR NOT `cb_my_table`.`id` = -2 OR `cb_my_table`.`id` IN (1, 2) GROUP BY `value`, `cb_my_table`.`id`, `cb_person_details`.`id` HAVING `tot` < 2 ORDER BY `cb_my_table`.`id` DESC, `value` ASC LIMIT 1 OFFSET 0) AS `bb`"
+			, $nestedQuery->getQuery()->getRawSql());
+	}
 
-    public function testSelectQueryWithNestedCriteriaAndJoins()
-    {
-        $builder = $this->builder;
+	public function testSelectQueryWithNestedCriteriaAndJoins() {
+		$builder = $this->builder;
 
-        $query = $builder->table('my_table')
-                         ->where('my_table.id', '>', 1)
-                         ->orWhere('my_table.id', 1)
-                         ->where(function ($q) {
-                             $q->where('value', 'LIKE', '%sana%');
-                             $q->orWhere(function ($q2) {
-                                 $q2->where('key', 'LIKE', '%sana%');
-                                 $q2->orWhere('value', 'LIKE', '%sana%');
-                             });
-                         })
-                         ->join(['person_details', 'a'], 'a.person_id', '=', 'my_table.id')
-                         ->leftJoin(['person_details', 'b'], function ($table) use ($builder) {
-                             $table->on('b.person_id', '=', 'my_table.id');
-                             $table->on('b.deleted', '=', $builder->raw(0));
-                             $table->orOn('b.age', '>', $builder->raw(1));
-                         })
-        ;
+		$query = $builder->table('my_table')
+		                 ->where('my_table.id', '>', 1)
+		                 ->orWhere('my_table.id', 1)
+		                 ->where(function ($q) {
+			                 $q->where('value', 'LIKE', '%sana%');
+			                 $q->orWhere(function ($q2) {
+				                 $q2->where('key', 'LIKE', '%sana%');
+				                 $q2->orWhere('value', 'LIKE', '%sana%');
+			                 });
+		                 })
+		                 ->join(['person_details', 'a'], 'a.person_id', '=', 'my_table.id')
+		                 ->leftJoin(['person_details', 'b'], function ($table) use ($builder) {
+			                 $table->on('b.person_id', '=', 'my_table.id');
+			                 $table->on('b.deleted', '=', $builder->raw(0));
+			                 $table->orOn('b.age', '>', $builder->raw(1));
+		                 });
 
-        $this->assertEquals("SELECT * FROM `cb_my_table` INNER JOIN `cb_person_details` AS `cb_a` ON `cb_a`.`person_id` = `cb_my_table`.`id` LEFT JOIN `cb_person_details` AS `cb_b` ON `cb_b`.`person_id` = `cb_my_table`.`id` AND `cb_b`.`deleted` = 0 OR `cb_b`.`age` > 1 WHERE `cb_my_table`.`id` > 1 OR `cb_my_table`.`id` = 1 AND (`value` LIKE '%sana%' OR (`key` LIKE '%sana%' OR `value` LIKE '%sana%'))"
-            , $query->getQuery()->getRawSql());
-    }
+		$this->assertEquals("SELECT * FROM `cb_my_table` INNER JOIN `cb_person_details` AS `cb_a` ON `cb_a`.`person_id` = `cb_my_table`.`id` LEFT JOIN `cb_person_details` AS `cb_b` ON `cb_b`.`person_id` = `cb_my_table`.`id` AND `cb_b`.`deleted` = 0 OR `cb_b`.`age` > 1 WHERE `cb_my_table`.`id` > 1 OR `cb_my_table`.`id` = 1 AND (`value` LIKE '%sana%' OR (`key` LIKE '%sana%' OR `value` LIKE '%sana%'))"
+			, $query->getQuery()->getRawSql());
+	}
 
-    public function testSelectQueryWithNull()
-    {
-        $query = $this->builder->from('my_table')
-                               ->whereNull('key1')
-                               ->orWhereNull('key2')
-                               ->whereNotNull('key3')
-                               ->orWhereNotNull('key4')
-                               ->orWhere('key5', '=', null)
-        ;
+	public function testSelectQueryWithNull() {
+		$query = $this->builder->from('my_table')
+		                       ->whereNull('key1')
+		                       ->orWhereNull('key2')
+		                       ->whereNotNull('key3')
+		                       ->orWhereNotNull('key4')
+		                       ->orWhere('key5', '=', null);
 
-        $this->assertEquals(
-            "SELECT * FROM `cb_my_table` WHERE `key1` IS NULL OR `key2` IS NULL AND `key3` IS NOT NULL OR `key4` IS NOT NULL OR `key5` = NULL",
-            $query->getQuery()->getRawSql()
-        );
-    }
+		$this->assertEquals(
+			"SELECT * FROM `cb_my_table` WHERE `key1` IS NULL OR `key2` IS NULL AND `key3` IS NOT NULL OR `key4` IS NOT NULL OR `key5` = NULL",
+			$query->getQuery()->getRawSql()
+		);
+	}
 
-    public function testSelectWithQueryEvents()
-    {
-        $builder = $this->builder;
+	public function testSelectWithQueryEvents() {
+		$builder = $this->builder;
 
-        $builder->registerEvent('before-select', ':any', function ($qb) {
-            $qb->whereIn('status', [1, 2]);
-        });
+		$builder->registerEvent('before-select', ':any', function ($qb) {
+			$qb->whereIn('status', [1, 2]);
+		});
 
-        $query = $builder->table('some_table')->where('name', 'Some');
-        $query->get();
-        $actual = $query->getQuery()->getRawSql();
+		$query = $builder->table('some_table')->where('name', 'Some');
+		$query->get();
+		$actual = $query->getQuery()->getRawSql();
 
-        $this->assertEquals("SELECT * FROM `cb_some_table` WHERE `name` = 'Some' AND `status` IN (1, 2)", $actual);
-    }
+		$this->assertEquals("SELECT * FROM `cb_some_table` WHERE `name` = 'Some' AND `status` IN (1, 2)", $actual);
+	}
 
-    public function testStandaloneWhereNot()
-    {
-        $query = $this->builder->table('my_table')->whereNot('foo', 1);
-        $this->assertEquals("SELECT * FROM `cb_my_table` WHERE NOT `foo` = 1", $query->getQuery()->getRawSql());
-    }
+	public function testStandaloneWhereNot() {
+		$query = $this->builder->table('my_table')->whereNot('foo', 1);
+		$this->assertEquals("SELECT * FROM `cb_my_table` WHERE NOT `foo` = 1", $query->getQuery()->getRawSql());
+	}
 
-    public function testUpdateQuery()
-    {
-        $builder = $this->builder->table('my_table')->where('value', 'Sana');
+	public function testUpdateQuery() {
+		$builder = $this->builder->table('my_table')->where('value', 'Sana');
 
-        $data = [
-            'key'   => 'Sana',
-            'value' => 'Amrin',
-        ];
+		$data = [
+			'key'   => 'Sana',
+			'value' => 'Amrin',
+		];
 
-        $this->assertEquals("UPDATE `cb_my_table` SET `key`='Sana',`value`='Amrin' WHERE `value` = 'Sana'"
-            , $builder->getQuery('update', $data)->getRawSql());
-    }
+		$this->assertEquals("UPDATE `cb_my_table` SET `key`='Sana',`value`='Amrin' WHERE `value` = 'Sana'"
+			, $builder->getQuery('update', $data)->getRawSql());
+	}
 
-    public function testFromSubQuery() {
+	public function testFromSubQuery() {
 
-        $subQuery = $this->builder->table('person');
-        $builder = $this->builder->table($this->builder->subQuery($subQuery))->where('id', '=', 2);
+		$subQuery = $this->builder->table('person');
+		$builder  = $this->builder->table($this->builder->subQuery($subQuery))->where('id', '=', 2);
 
-        $this->assertEquals('SELECT * FROM (SELECT * FROM `cb_person`) WHERE `id` = 2', $builder->getQuery()->getRawSql());
+		$this->assertEquals('SELECT * FROM (SELECT * FROM `cb_person`) WHERE `id` = 2', $builder->getQuery()->getRawSql());
 
-    }
+	}
 
-    public function testTableAlias() {
+	public function testTableAlias() {
 
-        $builder = $this->builder->table('persons')->alias('staff');
+		$builder = $this->builder->table('persons')->alias('staff');
 
-        $this->assertEquals('SELECT * FROM `cb_persons` AS `staff`', $builder->getQuery()->getRawSql());
+		$this->assertEquals('SELECT * FROM `cb_persons` AS `staff`', $builder->getQuery()->getRawSql());
 
-    }
+	}
 
-    public function testWhereNotNullSubQuery() {
-        $subQuery = $this->builder->table('persons')->alias('staff');
+	public function testWhereNotNullSubQuery() {
+		$subQuery = $this->builder->table('persons')->alias('staff');
 
-        $query = $this->builder->whereNull($this->builder->subQuery($subQuery));
+		$query = $this->builder->whereNull($this->builder->subQuery($subQuery));
 
-        $this->assertEquals('SELECT * WHERE (SELECT * FROM `cb_persons` AS `staff`) IS NULL', $query->getQuery()->getRawSql());
+		$this->assertEquals('SELECT * WHERE (SELECT * FROM `cb_persons` AS `staff`) IS NULL', $query->getQuery()->getRawSql());
 
-    }
+	}
 }

--- a/tests/Pecee/Pixie/QueryBuilderBehaviorTest.php
+++ b/tests/Pecee/Pixie/QueryBuilderBehaviorTest.php
@@ -18,153 +18,32 @@ class QueryBuilderTest extends TestCase
         $this->builder = new QueryBuilder\QueryBuilderHandler($this->mockConnection);
     }
 
-    public function testSelectFlexibility()
-    {
-        $query = $this->builder
-            ->select('foo')
-            ->select(array('bar', 'baz'))
-            ->select('qux', 'lol', 'wut')
-            ->from('t');
-        $this->assertEquals(
-            'SELECT `foo`, `bar`, `baz`, `qux`, `lol`, `wut` FROM `cb_t`',
-            $query->getQuery()->getRawSql(),
-            'SELECT is pretty flexible!'
-        );
-    }
-
+    /**
+     * Test alias
+     */
     public function testAlias()
     {
         $query = $this->builder
             ->table(['table1'])
-            ->alias('table1', 't1')
-            ->join('table2', 'table2.person_id', '=', 'foo2.id');
+            ->alias('t1')
+            ->join('table2', 'table2.person_id', '=', 'foo2.id')
+        ;
 
         $this->assertEquals('SELECT * FROM `cb_table1` AS `t1` INNER JOIN `cb_table2` ON `cb_table2`.`person_id` = `cb_foo2`.`id`',
             $query->getQuery()->getRawSql());
     }
 
-    public function testSelectQuery()
+    /**
+     * Test delete
+     */
+    public function testDeleteQuery()
     {
-        $subQuery = $this->builder->table('person_details')->select('details')->where('person_id', '=', 3);
+        $this->builder = new QueryBuilder\QueryBuilderHandler($this->mockConnection);
 
-        $query = $this->builder->table('my_table')
-            ->select('my_table.*')
-            ->select(array($this->builder->raw('count(cb_my_table.id) AS `tot`'), $this->builder->subQuery($subQuery, 'pop')))
-            ->where('value', '=', 'Ifrah')
-            ->whereNot('my_table.id', -1)
-            ->orWhereNot('my_table.id', -2)
-            ->orWhereIn('my_table.id', array(1, 2))
-            ->groupBy(array('value', 'my_table.id', 'person_details.id'))
-            ->orderBy('my_table.id', 'DESC')
-            ->orderBy('value')
-            ->having('tot', '<', 2)
-            ->limit(1)
-            ->offset(0)
-            ->join(
-                'person_details',
-                'person_details.person_id',
-                '=',
-                'my_table.id'
-            )
-        ;
+        $builder = $this->builder->table('my_table')->where('value', '=', 'Amrin');
 
-        $nestedQuery = $this->builder->table($this->builder->subQuery($query, 'bb'))->select('*');
-        $this->assertEquals("SELECT * FROM (SELECT `cb_my_table`.*, count(cb_my_table.id) AS `tot`, (SELECT `details` FROM `cb_person_details` WHERE `person_id` = 3) AS `pop` FROM `cb_my_table` INNER JOIN `cb_person_details` ON `cb_person_details`.`person_id` = `cb_my_table`.`id` WHERE `value` = 'Ifrah' AND NOT `cb_my_table`.`id` = -1 OR NOT `cb_my_table`.`id` = -2 OR `cb_my_table`.`id` IN (1, 2) GROUP BY `value`, `cb_my_table`.`id`, `cb_person_details`.`id` HAVING `tot` < 2 ORDER BY `cb_my_table`.`id` DESC, `value` ASC LIMIT 1 OFFSET 0) AS `bb`"
-            , $nestedQuery->getQuery()->getRawSql());
-    }
-
-    public function testSelectAliases()
-    {
-        $query = $this->builder->from('my_table')->select('foo')->select(array('bar' => 'baz', 'qux'));
-
-        $this->assertEquals(
-            "SELECT `foo`, `bar` AS `baz`, `qux` FROM `cb_my_table`",
-            $query->getQuery()->getRawSql()
-        );
-    }
-
-    public function testRawStatementsWithinCriteria()
-    {
-        $query = $this->builder->from('my_table')
-            ->where('simple', 'criteria')
-            ->where($this->builder->raw('RAW'))
-            ->where($this->builder->raw('PARAMETERIZED_ONE(?)', 'foo'))
-            ->where($this->builder->raw('PARAMETERIZED_SEVERAL(?, ?, ?)', array(1, '2', 'foo')));
-
-        $this->assertEquals(
-            "SELECT * FROM `cb_my_table` WHERE `simple` = 'criteria' AND RAW AND PARAMETERIZED_ONE('foo') AND PARAMETERIZED_SEVERAL(1, '2', 'foo')",
-            $query->getQuery()->getRawSql()
-        );
-    }
-
-    public function testStandaloneWhereNot()
-    {
-        $query = $this->builder->table('my_table')->whereNot('foo', 1);
-        $this->assertEquals("SELECT * FROM `cb_my_table` WHERE NOT `foo` = 1", $query->getQuery()->getRawSql());
-    }
-
-    public function testSelectDistinct()
-    {
-        $query = $this->builder->selectDistinct(array('name', 'surname'))->from('my_table');
-        $this->assertEquals("SELECT DISTINCT `name`, `surname` FROM `cb_my_table`", $query->getQuery()->getRawSql());
-    }
-
-    public function testSelectDistinctWithSingleColumn()
-    {
-        $query = $this->builder->selectDistinct('name')->from('my_table');
-        $this->assertEquals("SELECT DISTINCT `name` FROM `cb_my_table`", $query->getQuery()->getRawSql());
-    }
-
-    public function testSelectDistinctAndSelectCalls()
-    {
-        $query = $this->builder->select('name')->selectDistinct('surname')->select(array('birthday', 'address'))->from('my_table');
-        $this->assertEquals("SELECT DISTINCT `name`, `surname`, `birthday`, `address` FROM `cb_my_table`", $query->getQuery()->getRawSql());
-    }
-
-    public function testSelectQueryWithNestedCriteriaAndJoins()
-    {
-        $builder = $this->builder;
-
-        $query = $builder->table('my_table')
-            ->where('my_table.id', '>', 1)
-            ->orWhere('my_table.id', 1)
-            ->where(function($q)
-                {
-                    $q->where('value', 'LIKE', '%sana%');
-                    $q->orWhere(function($q2)
-                        {
-                            $q2->where('key', 'LIKE', '%sana%');
-                            $q2->orWhere('value', 'LIKE', '%sana%');
-                        });
-                })
-            ->join(array('person_details', 'a'), 'a.person_id', '=', 'my_table.id')
-
-            ->leftJoin(array('person_details', 'b'), function($table) use ($builder)
-                {
-                    $table->on('b.person_id', '=', 'my_table.id');
-                    $table->on('b.deleted', '=', $builder->raw(0));
-                    $table->orOn('b.age', '>', $builder->raw(1));
-                })
-        ;
-
-        $this->assertEquals("SELECT * FROM `cb_my_table` INNER JOIN `cb_person_details` AS `cb_a` ON `cb_a`.`person_id` = `cb_my_table`.`id` LEFT JOIN `cb_person_details` AS `cb_b` ON `cb_b`.`person_id` = `cb_my_table`.`id` AND `cb_b`.`deleted` = 0 OR `cb_b`.`age` > 1 WHERE `cb_my_table`.`id` > 1 OR `cb_my_table`.`id` = 1 AND (`value` LIKE '%sana%' OR (`key` LIKE '%sana%' OR `value` LIKE '%sana%'))"
-            , $query->getQuery()->getRawSql());
-    }
-
-    public function testSelectWithQueryEvents()
-    {
-        $builder = $this->builder;
-
-        $builder->registerEvent('before-select', ':any', function($qb)
-        {
-            $qb->whereIn('status', array(1, 2));
-        });
-
-        $query = $builder->table('some_table')->where('name', 'Some');
-        $query->get();
-        $actual = $query->getQuery()->getRawSql();
-
-        $this->assertEquals("SELECT * FROM `cb_some_table` WHERE `name` = 'Some' AND `status` IN (1, 2)", $actual);
+        $this->assertEquals("DELETE FROM `cb_my_table` WHERE `value` = 'Amrin'"
+            , $builder->getQuery('delete')->getRawSql());
     }
 
     public function testEventPropagation()
@@ -190,119 +69,61 @@ class QueryBuilderTest extends TestCase
             });
         }
 
-        $builder->table('foo')->insert(array('bar' => 'baz'));
+        $builder->table('foo')->insert(['bar' => 'baz']);
         $builder->from('foo')->select('bar')->get();
-        $builder->table('foo')->update(array('bar' => 'baz'));
+        $builder->table('foo')->update(['bar' => 'baz']);
         $builder->from('foo')->delete();
 
         $this->assertEquals($triggeredEvents, $events);
     }
 
-    public function testInsertQuery()
-    {
-        $builder = $this->builder->from('my_table');
-        $data = array('key' => 'Name',
-                'value' => 'Sana',);
-
-        $this->assertEquals("INSERT INTO `cb_my_table` (`key`,`value`) VALUES ('Name','Sana')"
-            , $builder->getQuery('insert', $data)->getRawSql());
-    }
-
     public function testInsertIgnoreQuery()
     {
         $builder = $this->builder->from('my_table');
-        $data = array('key' => 'Name',
-            'value' => 'Sana',);
+        $data    = [
+            'key'   => 'Name',
+            'value' => 'Sana',
+        ];
 
         $this->assertEquals("INSERT IGNORE INTO `cb_my_table` (`key`,`value`) VALUES ('Name','Sana')"
             , $builder->getQuery('insertignore', $data)->getRawSql());
     }
 
-    public function testReplaceQuery()
-    {
-        $builder = $this->builder->from('my_table');
-        $data = array('key' => 'Name',
-            'value' => 'Sana',);
-
-        $this->assertEquals("REPLACE INTO `cb_my_table` (`key`,`value`) VALUES ('Name','Sana')"
-            , $builder->getQuery('replace', $data)->getRawSql());
-    }
-
     public function testInsertOnDuplicateKeyUpdateQuery()
     {
-        $builder = $this->builder;
-        $data = array(
-            'name' => 'Sana',
-            'counter' => 1
-        );
-        $dataUpdate = array(
-            'name' => 'Sana',
-            'counter' => 2
-        );
+        $builder    = $this->builder;
+        $data       = [
+            'name'    => 'Sana',
+            'counter' => 1,
+        ];
+        $dataUpdate = [
+            'name'    => 'Sana',
+            'counter' => 2,
+        ];
         $builder->from('my_table')->onDuplicateKeyUpdate($dataUpdate);
         $this->assertEquals("INSERT INTO `cb_my_table` (`name`,`counter`) VALUES ('Sana',1) ON DUPLICATE KEY UPDATE `name`='Sana',`counter`=2"
             , $builder->getQuery('insert', $data)->getRawSql());
     }
 
-    public function testUpdateQuery()
+    public function testInsertQuery()
     {
-        $builder = $this->builder->table('my_table')->where('value', 'Sana');
+        $builder = $this->builder->from('my_table');
+        $data    = [
+            'key'   => 'Name',
+            'value' => 'Sana',
+        ];
 
-        $data = array(
-            'key' => 'Sana',
-            'value' => 'Amrin',
-        );
-
-        $this->assertEquals("UPDATE `cb_my_table` SET `key`='Sana',`value`='Amrin' WHERE `value` = 'Sana'"
-            , $builder->getQuery('update', $data)->getRawSql());
-    }
-
-    public function testDeleteQuery()
-    {
-        $this->builder = new QueryBuilder\QueryBuilderHandler($this->mockConnection);
-
-        $builder = $this->builder->table('my_table')->where('value', '=', 'Amrin');
-
-        $this->assertEquals("DELETE FROM `cb_my_table` WHERE `value` = 'Amrin'"
-            , $builder->getQuery('delete')->getRawSql());
-    }
-
-    public function testOrderByFlexibility()
-    {
-        $query = $this->builder
-            ->from('t')
-            ->orderBy('foo', 'DESC')
-            ->orderBy(array('bar', 'baz' => 'ASC', $this->builder->raw('raw1')), 'DESC')
-            ->orderBy($this->builder->raw('raw2'), 'DESC');
-
-        $this->assertEquals(
-            'SELECT * FROM `cb_t` ORDER BY `foo` DESC, `bar` DESC, `baz` ASC, raw1 DESC, raw2 DESC',
-            $query->getQuery()->getRawSql(),
-            'ORDER BY is flexible enough!'
-        );
-    }
-
-    public function testSelectQueryWithNull()
-    {
-        $query = $this->builder->from('my_table')
-                ->whereNull('key1')
-                ->orWhereNull('key2')
-                ->whereNotNull('key3')
-                ->orWhereNotNull('key4')
-                ->orWhere('key5', '=', null);
-
-        $this->assertEquals(
-            "SELECT * FROM `cb_my_table` WHERE `key1` IS  NULL OR `key2` IS  NULL AND `key3` IS NOT NULL OR `key4` IS NOT NULL OR `key5` = NULL",
-            $query->getQuery()->getRawSql()
-        );
+        $this->assertEquals("INSERT INTO `cb_my_table` (`key`,`value`) VALUES ('Name','Sana')"
+            , $builder->getQuery('insert', $data)->getRawSql());
     }
 
     public function testIsPossibleToUseSubqueryInWhereClause()
     {
-        $sub = clone $this->builder;
+        $sub   = clone $this->builder;
         $query = $this->builder->from('my_table')->whereIn('foo', $this->builder->subQuery(
             $sub->from('some_table')->select('foo')->where('id', 1)
-        ));
+        ))
+        ;
         $this->assertEquals(
             "SELECT * FROM `cb_my_table` WHERE `foo` IN (SELECT `foo` FROM `cb_some_table` WHERE `id` = 1)",
             $query->getQuery()->getRawSql()
@@ -311,13 +132,232 @@ class QueryBuilderTest extends TestCase
 
     public function testIsPossibleToUseSubqueryInWhereNotClause()
     {
-        $sub = clone $this->builder;
+        $sub   = clone $this->builder;
         $query = $this->builder->from('my_table')->whereNotIn('foo', $this->builder->subQuery(
             $sub->from('some_table')->select('foo')->where('id', 1)
-        ));
+        ))
+        ;
         $this->assertEquals(
             "SELECT * FROM `cb_my_table` WHERE `foo` NOT IN (SELECT `foo` FROM `cb_some_table` WHERE `id` = 1)",
             $query->getQuery()->getRawSql()
         );
+    }
+
+    public function testOrderByFlexibility()
+    {
+        $query = $this->builder
+            ->from('t')
+            ->orderBy('foo', 'DESC')
+            ->orderBy(['bar', 'baz' => 'ASC', $this->builder->raw('raw1')], 'DESC')
+            ->orderBy($this->builder->raw('raw2'), 'DESC')
+        ;
+
+        $this->assertEquals(
+            'SELECT * FROM `cb_t` ORDER BY `foo` DESC, `bar` DESC, `baz` ASC, raw1 DESC, raw2 DESC',
+            $query->getQuery()->getRawSql(),
+            'ORDER BY is flexible enough!'
+        );
+    }
+
+    public function testRawStatementsWithinCriteria()
+    {
+        $query = $this->builder->from('my_table')
+                               ->where('simple', 'criteria')
+                               ->where($this->builder->raw('RAW'))
+                               ->where($this->builder->raw('PARAMETERIZED_ONE(?)', 'foo'))
+                               ->where($this->builder->raw('PARAMETERIZED_SEVERAL(?, ?, ?)', [1, '2', 'foo']))
+        ;
+
+        $this->assertEquals(
+            "SELECT * FROM `cb_my_table` WHERE `simple` = 'criteria' AND RAW AND PARAMETERIZED_ONE('foo') AND PARAMETERIZED_SEVERAL(1, '2', 'foo')",
+            $query->getQuery()->getRawSql()
+        );
+    }
+
+    public function testReplaceQuery()
+    {
+        $builder = $this->builder->from('my_table');
+        $data    = [
+            'key'   => 'Name',
+            'value' => 'Sana',
+        ];
+
+        $this->assertEquals("REPLACE INTO `cb_my_table` (`key`,`value`) VALUES ('Name','Sana')"
+            , $builder->getQuery('replace', $data)->getRawSql());
+    }
+
+    public function testSelectAliases()
+    {
+        $query = $this->builder->from('my_table')->select('foo')->select(['bar' => 'baz', 'qux']);
+
+        $this->assertEquals(
+            "SELECT `foo`, `bar` AS `baz`, `qux` FROM `cb_my_table`",
+            $query->getQuery()->getRawSql()
+        );
+    }
+
+    public function testSelectDistinct()
+    {
+        $query = $this->builder->selectDistinct(['name', 'surname'])->from('my_table');
+        $this->assertEquals("SELECT DISTINCT `name`, `surname` FROM `cb_my_table`", $query->getQuery()->getRawSql());
+    }
+
+    public function testSelectDistinctAndSelectCalls()
+    {
+        $query = $this->builder->select('name')->selectDistinct('surname')->select(['birthday', 'address'])->from('my_table');
+        $this->assertEquals("SELECT DISTINCT `name`, `surname`, `birthday`, `address` FROM `cb_my_table`", $query->getQuery()->getRawSql());
+    }
+
+    public function testSelectDistinctWithSingleColumn()
+    {
+        $query = $this->builder->selectDistinct('name')->from('my_table');
+        $this->assertEquals("SELECT DISTINCT `name` FROM `cb_my_table`", $query->getQuery()->getRawSql());
+    }
+
+    public function testSelectFlexibility()
+    {
+        $query = $this->builder
+            ->select('foo')
+            ->select(['bar', 'baz'])
+            ->select('qux', 'lol', 'wut')
+            ->from('t')
+        ;
+        $this->assertEquals(
+            'SELECT `foo`, `bar`, `baz`, `qux`, `lol`, `wut` FROM `cb_t`',
+            $query->getQuery()->getRawSql(),
+            'SELECT is pretty flexible!'
+        );
+    }
+
+    public function testSelectQuery()
+    {
+        $subQuery = $this->builder->table('person_details')->select('details')->where('person_id', '=', 3);
+
+        $query = $this->builder->table('my_table')
+                               ->select('my_table.*')
+                               ->select([$this->builder->raw('count(cb_my_table.id) AS `tot`'), $this->builder->subQuery($subQuery, 'pop')])
+                               ->where('value', '=', 'Ifrah')
+                               ->whereNot('my_table.id', -1)
+                               ->orWhereNot('my_table.id', -2)
+                               ->orWhereIn('my_table.id', [1, 2])
+                               ->groupBy(['value', 'my_table.id', 'person_details.id'])
+                               ->orderBy('my_table.id', 'DESC')
+                               ->orderBy('value')
+                               ->having('tot', '<', 2)
+                               ->limit(1)
+                               ->offset(0)
+                               ->join(
+                                   'person_details',
+                                   'person_details.person_id',
+                                   '=',
+                                   'my_table.id'
+                               )
+        ;
+
+        $nestedQuery = $this->builder->table($this->builder->subQuery($query, 'bb'))->select('*');
+        $this->assertEquals("SELECT * FROM (SELECT `cb_my_table`.*, count(cb_my_table.id) AS `tot`, (SELECT `details` FROM `cb_person_details` WHERE `person_id` = 3) AS `pop` FROM `cb_my_table` INNER JOIN `cb_person_details` ON `cb_person_details`.`person_id` = `cb_my_table`.`id` WHERE `value` = 'Ifrah' AND NOT `cb_my_table`.`id` = -1 OR NOT `cb_my_table`.`id` = -2 OR `cb_my_table`.`id` IN (1, 2) GROUP BY `value`, `cb_my_table`.`id`, `cb_person_details`.`id` HAVING `tot` < 2 ORDER BY `cb_my_table`.`id` DESC, `value` ASC LIMIT 1 OFFSET 0) AS `bb`"
+            , $nestedQuery->getQuery()->getRawSql());
+    }
+
+    public function testSelectQueryWithNestedCriteriaAndJoins()
+    {
+        $builder = $this->builder;
+
+        $query = $builder->table('my_table')
+                         ->where('my_table.id', '>', 1)
+                         ->orWhere('my_table.id', 1)
+                         ->where(function ($q) {
+                             $q->where('value', 'LIKE', '%sana%');
+                             $q->orWhere(function ($q2) {
+                                 $q2->where('key', 'LIKE', '%sana%');
+                                 $q2->orWhere('value', 'LIKE', '%sana%');
+                             });
+                         })
+                         ->join(['person_details', 'a'], 'a.person_id', '=', 'my_table.id')
+                         ->leftJoin(['person_details', 'b'], function ($table) use ($builder) {
+                             $table->on('b.person_id', '=', 'my_table.id');
+                             $table->on('b.deleted', '=', $builder->raw(0));
+                             $table->orOn('b.age', '>', $builder->raw(1));
+                         })
+        ;
+
+        $this->assertEquals("SELECT * FROM `cb_my_table` INNER JOIN `cb_person_details` AS `cb_a` ON `cb_a`.`person_id` = `cb_my_table`.`id` LEFT JOIN `cb_person_details` AS `cb_b` ON `cb_b`.`person_id` = `cb_my_table`.`id` AND `cb_b`.`deleted` = 0 OR `cb_b`.`age` > 1 WHERE `cb_my_table`.`id` > 1 OR `cb_my_table`.`id` = 1 AND (`value` LIKE '%sana%' OR (`key` LIKE '%sana%' OR `value` LIKE '%sana%'))"
+            , $query->getQuery()->getRawSql());
+    }
+
+    public function testSelectQueryWithNull()
+    {
+        $query = $this->builder->from('my_table')
+                               ->whereNull('key1')
+                               ->orWhereNull('key2')
+                               ->whereNotNull('key3')
+                               ->orWhereNotNull('key4')
+                               ->orWhere('key5', '=', null)
+        ;
+
+        $this->assertEquals(
+            "SELECT * FROM `cb_my_table` WHERE `key1` IS NULL OR `key2` IS NULL AND `key3` IS NOT NULL OR `key4` IS NOT NULL OR `key5` = NULL",
+            $query->getQuery()->getRawSql()
+        );
+    }
+
+    public function testSelectWithQueryEvents()
+    {
+        $builder = $this->builder;
+
+        $builder->registerEvent('before-select', ':any', function ($qb) {
+            $qb->whereIn('status', [1, 2]);
+        });
+
+        $query = $builder->table('some_table')->where('name', 'Some');
+        $query->get();
+        $actual = $query->getQuery()->getRawSql();
+
+        $this->assertEquals("SELECT * FROM `cb_some_table` WHERE `name` = 'Some' AND `status` IN (1, 2)", $actual);
+    }
+
+    public function testStandaloneWhereNot()
+    {
+        $query = $this->builder->table('my_table')->whereNot('foo', 1);
+        $this->assertEquals("SELECT * FROM `cb_my_table` WHERE NOT `foo` = 1", $query->getQuery()->getRawSql());
+    }
+
+    public function testUpdateQuery()
+    {
+        $builder = $this->builder->table('my_table')->where('value', 'Sana');
+
+        $data = [
+            'key'   => 'Sana',
+            'value' => 'Amrin',
+        ];
+
+        $this->assertEquals("UPDATE `cb_my_table` SET `key`='Sana',`value`='Amrin' WHERE `value` = 'Sana'"
+            , $builder->getQuery('update', $data)->getRawSql());
+    }
+
+    public function testFromSubQuery() {
+
+        $subQuery = $this->builder->table('person');
+        $builder = $this->builder->table($this->builder->subQuery($subQuery))->where('id', '=', 2);
+
+        $this->assertEquals('SELECT * FROM (SELECT * FROM `cb_person`) WHERE `id` = 2', $builder->getQuery()->getRawSql());
+
+    }
+
+    public function testTableAlias() {
+
+        $builder = $this->builder->table('persons')->alias('staff');
+
+        $this->assertEquals('SELECT * FROM `cb_persons` AS `staff`', $builder->getQuery()->getRawSql());
+
+    }
+
+    public function testWhereNotNullSubQuery() {
+        $subQuery = $this->builder->table('persons')->alias('staff');
+
+        $query = $this->builder->whereNull($this->builder->subQuery($subQuery));
+
+        $this->assertEquals('SELECT * WHERE (SELECT * FROM `cb_persons` AS `staff`) IS NULL', $query->getQuery()->getRawSql());
+
     }
 }

--- a/tests/Pecee/Pixie/QueryBuilderTest.php
+++ b/tests/Pecee/Pixie/QueryBuilderTest.php
@@ -1,117 +1,100 @@
 <?php
+
 namespace Pecee\Pixie;
 
-use PDO;
-use Mockery as m;
 use Pecee\Pixie\QueryBuilder\QueryBuilderHandler;
 
-class QueryBuilder extends TestCase
-{
-    /**
-     * @var QueryBuilderHandler
-     */
-    protected $builder;
+class QueryBuilder extends TestCase {
+	/**
+	 * @var QueryBuilderHandler
+	 */
+	protected $builder;
 
-    /**
-     * Setup
-     */
-    public function setUp()
-    {
-        parent::setUp();
+	/**
+	 * Setup
+	 */
+	public function setUp() {
+		parent::setUp();
 
-        $this->builder = new QueryBuilderHandler($this->mockConnection);
-    }
+		$this->builder = new QueryBuilderHandler($this->mockConnection);
+	}
 
-    public function testFalseBoolWhere()
-    {
-        $result = $this->builder->table('test')->where('id', '=', false);
-        $this->assertEquals('SELECT * FROM `cb_test` WHERE `id` = 0', $result->getQuery()->getRawSql());
-    }
+	public function testFalseBoolWhere() {
+		$result = $this->builder->table('test')->where('id', '=', false);
+		$this->assertEquals('SELECT * FROM `cb_test` WHERE `id` = 0', $result->getQuery()->getRawSql());
+	}
 
-    public function testInsertQueryReturnsIdForInsert()
-    {
-        $this->mockPdoStatement
-            ->expects($this->once())
-            ->method('rowCount')
-            ->will($this->returnValue(1))
-        ;
+	public function testInsertQueryReturnsIdForInsert() {
+		$this->mockPdoStatement
+			->expects($this->once())
+			->method('rowCount')
+			->will($this->returnValue(1));
 
-        $this->mockPdo
-            ->expects($this->once())
-            ->method('lastInsertId')
-            ->will($this->returnValue(11))
-        ;
+		$this->mockPdo
+			->expects($this->once())
+			->method('lastInsertId')
+			->will($this->returnValue(11));
 
-        $id = $this->builder->table('test')->insert([
-            'id'   => 5,
-            'name' => 'usman',
-        ])
-        ;
+		$id = $this->builder->table('test')->insert([
+			'id'   => 5,
+			'name' => 'usman',
+		]);
 
-        $this->assertEquals(11, $id);
-    }
+		$this->assertEquals(11, $id);
+	}
 
-    public function testInsertQueryReturnsIdForInsertIgnore()
-    {
-        $this->mockPdoStatement
-            ->expects($this->once())
-            ->method('rowCount')
-            ->will($this->returnValue(1))
-        ;
+	public function testInsertQueryReturnsIdForInsertIgnore() {
+		$this->mockPdoStatement
+			->expects($this->once())
+			->method('rowCount')
+			->will($this->returnValue(1));
 
-        $this->mockPdo
-            ->expects($this->once())
-            ->method('lastInsertId')
-            ->will($this->returnValue(11))
-        ;
+		$this->mockPdo
+			->expects($this->once())
+			->method('lastInsertId')
+			->will($this->returnValue(11));
 
-        $id = $this->builder->table('test')->insertIgnore([
-            'id'   => 5,
-            'name' => 'usman',
-        ])
-        ;
+		$id = $this->builder->table('test')->insertIgnore([
+			'id'   => 5,
+			'name' => 'usman',
+		]);
 
-        $this->assertEquals(11, $id);
-    }
+		$this->assertEquals(11, $id);
+	}
 
-    public function testInsertQueryReturnsNullForIgnoredInsert()
-    {
-        $this->mockPdoStatement
-            ->expects($this->once())
-            ->method('rowCount')
-            ->will($this->returnValue(0))
-        ;
+	public function testInsertQueryReturnsNullForIgnoredInsert() {
+		$this->mockPdoStatement
+			->expects($this->once())
+			->method('rowCount')
+			->will($this->returnValue(0));
 
-        $id = $this->builder->table('test')->insertIgnore([
-            'id'   => 5,
-            'name' => 'usman',
-        ])
-        ;
+		$id = $this->builder->table('test')->insertIgnore([
+			'id'   => 5,
+			'name' => 'usman',
+		]);
 
-        $this->assertEquals(null, $id);
-    }
+		$this->assertEquals(null, $id);
+	}
 
-    public function testRawQuery()
-    {
-        $query    = 'select * from cb_my_table where id = ? and name = ? and hipster = null';
-        $bindings = [5, 'usman', null];
-        $queryArr = $this->builder->query($query, $bindings)->get();
+	public function testRawQuery() {
+		$query    = 'select * from cb_my_table where id = ? and name = ? and hipster = null';
+		$bindings = [5, 'usman', null];
+		$queryArr = $this->builder->query($query, $bindings)->get();
 
-        $this->assertEquals(
-            [
-                $query,
-                [5, 'usman', null],
-            ],
-            $queryArr
-        );
-    }
+		$this->assertEquals(
+			[
+				$query,
+				[5, 'usman', null],
+			],
+			$queryArr
+		);
+	}
 
-    public function testNullableWhere()
-    {
-        $query = $this->builder->table('person')->where('name', [1,null,3]);
+	public function testNullableWhere() {
+		$query = $this->builder->table('person')->where('name', [1, null, 3]);
 
-        $this->assertEquals($query->getQuery()->getRawSql(), 'SELECT * FROM `cb_person` WHERE `name` = (1, NULL, 3)');
+		$this->assertEquals($query->getQuery()->getRawSql(), 'SELECT * FROM `cb_person` WHERE `name` = (1, NULL, 3)');
 
-    }
+	}
 
 }

--- a/tests/Pecee/Pixie/QueryBuilderTest.php
+++ b/tests/Pecee/Pixie/QueryBuilderTest.php
@@ -12,6 +12,9 @@ class QueryBuilder extends TestCase
      */
     protected $builder;
 
+    /**
+     * Setup
+     */
     public function setUp()
     {
         parent::setUp();
@@ -19,18 +22,10 @@ class QueryBuilder extends TestCase
         $this->builder = new QueryBuilderHandler($this->mockConnection);
     }
 
-    public function testRawQuery()
+    public function testFalseBoolWhere()
     {
-        $query = 'select * from cb_my_table where id = ? and name = ?';
-        $bindings = array(5, 'usman');
-        $queryArr = $this->builder->query($query, $bindings)->get();
-        $this->assertEquals(
-            array(
-                $query,
-                array(array(5, PDO::PARAM_INT), array('usman', PDO::PARAM_STR)),
-            ),
-            $queryArr
-        );
+        $result = $this->builder->table('test')->where('id', '=', false);
+        $this->assertEquals('SELECT * FROM `cb_test` WHERE `id` = 0', $result->getQuery()->getRawSql());
     }
 
     public function testInsertQueryReturnsIdForInsert()
@@ -38,17 +33,20 @@ class QueryBuilder extends TestCase
         $this->mockPdoStatement
             ->expects($this->once())
             ->method('rowCount')
-            ->will($this->returnValue(1));
+            ->will($this->returnValue(1))
+        ;
 
         $this->mockPdo
             ->expects($this->once())
             ->method('lastInsertId')
-            ->will($this->returnValue(11));
+            ->will($this->returnValue(11))
+        ;
 
-        $id = $this->builder->table('test')->insert(array(
-            'id' => 5,
-            'name' => 'usman'
-        ));
+        $id = $this->builder->table('test')->insert([
+            'id'   => 5,
+            'name' => 'usman',
+        ])
+        ;
 
         $this->assertEquals(11, $id);
     }
@@ -58,17 +56,20 @@ class QueryBuilder extends TestCase
         $this->mockPdoStatement
             ->expects($this->once())
             ->method('rowCount')
-            ->will($this->returnValue(1));
+            ->will($this->returnValue(1))
+        ;
 
         $this->mockPdo
             ->expects($this->once())
             ->method('lastInsertId')
-            ->will($this->returnValue(11));
+            ->will($this->returnValue(11))
+        ;
 
-        $id = $this->builder->table('test')->insertIgnore(array(
-            'id' => 5,
-            'name' => 'usman'
-        ));
+        $id = $this->builder->table('test')->insertIgnore([
+            'id'   => 5,
+            'name' => 'usman',
+        ])
+        ;
 
         $this->assertEquals(11, $id);
     }
@@ -78,19 +79,39 @@ class QueryBuilder extends TestCase
         $this->mockPdoStatement
             ->expects($this->once())
             ->method('rowCount')
-            ->will($this->returnValue(0));
+            ->will($this->returnValue(0))
+        ;
 
-        $id = $this->builder->table('test')->insertIgnore(array(
-            'id' => 5,
-            'name' => 'usman'
-        ));
+        $id = $this->builder->table('test')->insertIgnore([
+            'id'   => 5,
+            'name' => 'usman',
+        ])
+        ;
 
         $this->assertEquals(null, $id);
     }
 
-    public function testFalseBoolWhere() {
-        $result = $this->builder->table('test')->where('id', '=', false);
-        $this->assertEquals('SELECT * FROM `cb_test` WHERE `id` = 0', $result->getQuery()->getRawSql());
+    public function testRawQuery()
+    {
+        $query    = 'select * from cb_my_table where id = ? and name = ? and hipster = null';
+        $bindings = [5, 'usman', null];
+        $queryArr = $this->builder->query($query, $bindings)->get();
+
+        $this->assertEquals(
+            [
+                $query,
+                [5, 'usman', null],
+            ],
+            $queryArr
+        );
+    }
+
+    public function testNullableWhere()
+    {
+        $query = $this->builder->table('person')->where('name', [1,null,3]);
+
+        $this->assertEquals($query->getQuery()->getRawSql(), 'SELECT * FROM `cb_person` WHERE `name` = (1, NULL, 3)');
+
     }
 
 }

--- a/tests/Pecee/Pixie/TransactionTest.php
+++ b/tests/Pecee/Pixie/TransactionTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Pecee\Pixie;
+
+use Pecee\Pixie\QueryBuilder\QueryBuilderHandler;
+use Pecee\Pixie\QueryBuilder\Transaction;
+
+/**
+ * Class QueryBuilderTest
+ *
+ * @package Pecee\Pixie
+ */
+class TransactionTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var QueryBuilderHandler
+     */
+    private $builder;
+
+    public function setUp()
+    {
+        // NOTE: This test will require a live PDO connection
+
+        $connection = new \Pecee\Pixie\Connection('mysql', [
+            'driver' => 'mysql',
+            'host' => '127.0.0.1',
+            'database' => 'test',
+            'username' => 'root',
+            'password' => '123456',
+            'charset' => 'utf8mb4', // Optional
+            'collation' => 'utf8mb4_unicode_ci', // Optional
+            'prefix' => '', // Table prefix, optional
+        ]);
+
+        $this->builder = $connection->getQueryBuilder();
+
+    }
+
+    public function testTransactionResult()
+    {
+
+        $this->builder->statement('TRUNCATE `people`');
+
+        $ids = [];
+
+        $this->builder->transaction(function (Transaction $q) use (&$ids) {
+
+            $ids = $q->table('people')->insert([
+                [
+                    'name' => 'Simon',
+                    'age' => 12,
+                    'awesome' => true,
+                    'nickname' => 'ponylover94',
+                ],
+                [
+                    'name' => 'Peter',
+                    'age' => 40,
+                    'awesome' => false,
+                    'nickname' => null,
+                ],
+                [
+                    'name' => 'Bobby',
+                    'age' => 20,
+                    'awesome' => true,
+                    'nickname' => 'peter',
+                ],
+            ]);
+
+        });
+
+        $this->assertEquals(1, $ids[0]);
+        $this->assertEquals(2, $ids[1]);
+        $this->assertEquals(3, $ids[2]);
+
+        $this->assertEquals($this->builder->table('people')->count(), 3);
+
+    }
+
+
+    /**
+     * @throws Exception
+     */
+    public function testNestedTransactions()
+    {
+
+        $this->builder->statement('TRUNCATE `people`; TRUNCATE `animals`');
+
+        function getAnimals()
+        {
+            return [
+                ['name' => 'mouse', 'number_of_legs' => '28'],
+                ['name' => 'horse', 'number_of_legs' => '4'],
+                ['name' => 'cat', 'number_of_legs' => '8']
+            ];
+        }
+
+        function getPersons()
+        {
+            return
+            [
+                [
+                    'name' => 'Osama',
+                    'age' => '2',
+                    'awesome' => '1',
+                    'nickname' => 'jihad4evar',
+                ],
+                [
+                    'name' => 'Leila',
+                    'age' => '76',
+                    'awesome' => '1',
+                    'nickname' => 'coolcatlady',
+                ],
+                [
+                    'name' => 'Henry',
+                    'age' => '56',
+                    'awesome' => '1',
+                    'nickname' => 'ponylover95',
+                ]
+            ];
+        }
+
+        $this->builder->transaction(function (Transaction $qb) {
+
+            function firstTrans(Transaction $oQuery)
+            {
+
+                $oQuery->transaction(function (Transaction $qb) {
+
+                    $qb->table('animal')->insert([
+                        getAnimals()
+                    ]);
+
+                });
+            }
+
+            function secondTrans(Transaction $oQuery)
+            {
+                $oQuery->transaction(function (\Pecee\Pixie\QueryBuilder\Transaction $qb) {
+
+                    $qb->table('people')->insert([
+                        getPersons()
+                    ]);
+
+                });
+            }
+
+            firstTrans($qb);
+            secondTrans($qb);
+
+        });
+
+
+        $animals = $this->builder->table('animal')->select(['name', 'number_of_legs'])->get();
+        $persons = $this->builder->table('people')->select(['name', 'age', 'awesome', 'nickname'])->get();
+
+        $originalPersons = getPersons();
+        $originalAnimals = getAnimals();
+
+        $this->assertSameSize($persons, $originalPersons);
+        $this->assertEquals((array)$persons[0], $originalPersons[0]);
+        $this->assertEquals((array)$persons[1], $originalPersons[1]);
+        $this->assertEquals((array)$persons[2], $originalPersons[2]);
+
+        $this->assertSameSize($animals, $originalAnimals);
+        $this->assertEquals((array)$animals[0], $originalAnimals[0]);
+        $this->assertEquals((array)$animals[1], $originalAnimals[1]);
+    }
+
+    public function testTransactionMultipleInsert()
+    {
+        $this->builder->statement('TRUNCATE `people`');
+
+        $ids = $this->builder->table('people')->insert([
+            [
+                'name' => 'Simon',
+                'age' => 12,
+                'awesome' => true,
+                'nickname' => 'ponylover94',
+            ],
+            [
+                'name' => 'Peter',
+                'age' => 40,
+                'awesome' => false,
+                'nickname' => null,
+            ],
+            [
+                'name' => 'Bobby',
+                'age' => 20,
+                'awesome' => true,
+                'nickname' => 'peter',
+            ],
+        ]);
+
+        $this->assertEquals(1, $ids[0]);
+        $this->assertEquals(2, $ids[1]);
+        $this->assertEquals(3, $ids[2]);
+
+        $this->assertEquals($this->builder->table('people')->count(), 3);
+
+    }
+
+}

--- a/tests/Pecee/Pixie/TransactionTest.php
+++ b/tests/Pecee/Pixie/TransactionTest.php
@@ -10,193 +10,184 @@ use Pecee\Pixie\QueryBuilder\Transaction;
  *
  * @package Pecee\Pixie
  */
-class TransactionTest extends \PHPUnit\Framework\TestCase
-{
-    /**
-     * @var QueryBuilderHandler
-     */
-    private $builder;
+class TransactionTest extends \PHPUnit\Framework\TestCase {
+	/**
+	 * @var QueryBuilderHandler
+	 */
+	private $builder;
 
-    public function setUp()
-    {
-        // NOTE: This test will require a live PDO connection
+	public function setUp() {
+		// NOTE: This test will require a live PDO connection
 
-        $connection = new \Pecee\Pixie\Connection('mysql', [
-            'driver' => 'mysql',
-            'host' => '127.0.0.1',
-            'database' => 'test',
-            'username' => 'root',
-            'password' => '123456',
-            'charset' => 'utf8mb4', // Optional
-            'collation' => 'utf8mb4_unicode_ci', // Optional
-            'prefix' => '', // Table prefix, optional
-        ]);
+		$connection = new \Pecee\Pixie\Connection('mysql', [
+			'driver'    => 'mysql',
+			'host'      => '127.0.0.1',
+			'database'  => 'test',
+			'username'  => 'root',
+			'password'  => '123456',
+			'charset'   => 'utf8mb4', // Optional
+			'collation' => 'utf8mb4_unicode_ci', // Optional
+			'prefix'    => '', // Table prefix, optional
+		]);
 
-        $this->builder = $connection->getQueryBuilder();
+		$this->builder = $connection->getQueryBuilder();
 
-    }
+	}
 
-    public function testTransactionResult()
-    {
+	public function testTransactionResult() {
 
-        $this->builder->statement('TRUNCATE `people`');
+		$this->builder->statement('TRUNCATE `people`');
 
-        $ids = [];
+		$ids = [];
 
-        $this->builder->transaction(function (Transaction $q) use (&$ids) {
+		$this->builder->transaction(function (Transaction $q) use (&$ids) {
 
-            $ids = $q->table('people')->insert([
-                [
-                    'name' => 'Simon',
-                    'age' => 12,
-                    'awesome' => true,
-                    'nickname' => 'ponylover94',
-                ],
-                [
-                    'name' => 'Peter',
-                    'age' => 40,
-                    'awesome' => false,
-                    'nickname' => null,
-                ],
-                [
-                    'name' => 'Bobby',
-                    'age' => 20,
-                    'awesome' => true,
-                    'nickname' => 'peter',
-                ],
-            ]);
+			$ids = $q->table('people')->insert([
+				[
+					'name'     => 'Simon',
+					'age'      => 12,
+					'awesome'  => true,
+					'nickname' => 'ponylover94',
+				],
+				[
+					'name'     => 'Peter',
+					'age'      => 40,
+					'awesome'  => false,
+					'nickname' => null,
+				],
+				[
+					'name'     => 'Bobby',
+					'age'      => 20,
+					'awesome'  => true,
+					'nickname' => 'peter',
+				],
+			]);
 
-        });
+		});
 
-        $this->assertEquals(1, $ids[0]);
-        $this->assertEquals(2, $ids[1]);
-        $this->assertEquals(3, $ids[2]);
+		$this->assertEquals(1, $ids[0]);
+		$this->assertEquals(2, $ids[1]);
+		$this->assertEquals(3, $ids[2]);
 
-        $this->assertEquals($this->builder->table('people')->count(), 3);
+		$this->assertEquals($this->builder->table('people')->count(), 3);
 
-    }
+	}
 
 
-    /**
-     * @throws Exception
-     */
-    public function testNestedTransactions()
-    {
+	/**
+	 * @throws Exception
+	 */
+	public function testNestedTransactions() {
 
-        $this->builder->statement('TRUNCATE `people`; TRUNCATE `animals`');
+		$this->builder->statement('TRUNCATE `people`; TRUNCATE `animal`');
 
-        function getAnimals()
-        {
-            return [
-                ['name' => 'mouse', 'number_of_legs' => '28'],
-                ['name' => 'horse', 'number_of_legs' => '4'],
-                ['name' => 'cat', 'number_of_legs' => '8']
-            ];
-        }
+		function getAnimals() {
+			return [
+				['name' => 'mouse', 'number_of_legs' => '28'],
+				['name' => 'horse', 'number_of_legs' => '4'],
+				['name' => 'cat', 'number_of_legs' => '8']
+			];
+		}
 
-        function getPersons()
-        {
-            return
-            [
-                [
-                    'name' => 'Osama',
-                    'age' => '2',
-                    'awesome' => '1',
-                    'nickname' => 'jihad4evar',
-                ],
-                [
-                    'name' => 'Leila',
-                    'age' => '76',
-                    'awesome' => '1',
-                    'nickname' => 'coolcatlady',
-                ],
-                [
-                    'name' => 'Henry',
-                    'age' => '56',
-                    'awesome' => '1',
-                    'nickname' => 'ponylover95',
-                ]
-            ];
-        }
+		function getPersons() {
+			return
+				[
+					[
+						'name'     => 'Osama',
+						'age'      => '2',
+						'awesome'  => '1',
+						'nickname' => 'jihad4evar',
+					],
+					[
+						'name'     => 'Leila',
+						'age'      => '76',
+						'awesome'  => '1',
+						'nickname' => 'coolcatlady',
+					],
+					[
+						'name'     => 'Henry',
+						'age'      => '56',
+						'awesome'  => '1',
+						'nickname' => 'ponylover95',
+					]
+				];
+		}
 
-        $this->builder->transaction(function (Transaction $qb) {
+		$this->builder->transaction(function (Transaction $qb) {
 
-            function firstTrans(Transaction $oQuery)
-            {
+			function firstTrans(Transaction $oQuery) {
 
-                $oQuery->transaction(function (Transaction $qb) {
+				$oQuery->transaction(function (Transaction $qb) {
 
-                    $qb->table('animal')->insert([
-                        getAnimals()
-                    ]);
+					$qb->table('animal')->insert([
+						getAnimals()
+					]);
 
-                });
-            }
+				});
+			}
 
-            function secondTrans(Transaction $oQuery)
-            {
-                $oQuery->transaction(function (\Pecee\Pixie\QueryBuilder\Transaction $qb) {
+			function secondTrans(Transaction $oQuery) {
+				$oQuery->transaction(function (\Pecee\Pixie\QueryBuilder\Transaction $qb) {
 
-                    $qb->table('people')->insert([
-                        getPersons()
-                    ]);
+					$qb->table('people')->insert([
+						getPersons()
+					]);
 
-                });
-            }
+				});
+			}
 
-            firstTrans($qb);
-            secondTrans($qb);
+			firstTrans($qb);
+			secondTrans($qb);
 
-        });
+		});
 
 
-        $animals = $this->builder->table('animal')->select(['name', 'number_of_legs'])->get();
-        $persons = $this->builder->table('people')->select(['name', 'age', 'awesome', 'nickname'])->get();
+		$animals = $this->builder->table('animal')->select(['name', 'number_of_legs'])->get();
+		$persons = $this->builder->table('people')->select(['name', 'age', 'awesome', 'nickname'])->get();
 
-        $originalPersons = getPersons();
-        $originalAnimals = getAnimals();
+		$originalPersons = getPersons();
+		$originalAnimals = getAnimals();
 
-        $this->assertSameSize($persons, $originalPersons);
-        $this->assertEquals((array)$persons[0], $originalPersons[0]);
-        $this->assertEquals((array)$persons[1], $originalPersons[1]);
-        $this->assertEquals((array)$persons[2], $originalPersons[2]);
+		$this->assertSameSize($persons, $originalPersons);
+		$this->assertEquals((array)$persons[0], $originalPersons[0]);
+		$this->assertEquals((array)$persons[1], $originalPersons[1]);
+		$this->assertEquals((array)$persons[2], $originalPersons[2]);
 
-        $this->assertSameSize($animals, $originalAnimals);
-        $this->assertEquals((array)$animals[0], $originalAnimals[0]);
-        $this->assertEquals((array)$animals[1], $originalAnimals[1]);
-    }
+		$this->assertSameSize($animals, $originalAnimals);
+		$this->assertEquals((array)$animals[0], $originalAnimals[0]);
+		$this->assertEquals((array)$animals[1], $originalAnimals[1]);
+	}
 
-    public function testTransactionMultipleInsert()
-    {
-        $this->builder->statement('TRUNCATE `people`');
+	public function testTransactionMultipleInsert() {
+		$this->builder->statement('TRUNCATE `people`');
 
-        $ids = $this->builder->table('people')->insert([
-            [
-                'name' => 'Simon',
-                'age' => 12,
-                'awesome' => true,
-                'nickname' => 'ponylover94',
-            ],
-            [
-                'name' => 'Peter',
-                'age' => 40,
-                'awesome' => false,
-                'nickname' => null,
-            ],
-            [
-                'name' => 'Bobby',
-                'age' => 20,
-                'awesome' => true,
-                'nickname' => 'peter',
-            ],
-        ]);
+		$ids = $this->builder->table('people')->insert([
+			[
+				'name'     => 'Simon',
+				'age'      => 12,
+				'awesome'  => true,
+				'nickname' => 'ponylover94',
+			],
+			[
+				'name'     => 'Peter',
+				'age'      => 40,
+				'awesome'  => false,
+				'nickname' => null,
+			],
+			[
+				'name'     => 'Bobby',
+				'age'      => 20,
+				'awesome'  => true,
+				'nickname' => 'peter',
+			],
+		]);
 
-        $this->assertEquals(1, $ids[0]);
-        $this->assertEquals(2, $ids[1]);
-        $this->assertEquals(3, $ids[2]);
+		$this->assertEquals(1, $ids[0]);
+		$this->assertEquals(2, $ids[1]);
+		$this->assertEquals(3, $ids[2]);
 
-        $this->assertEquals($this->builder->table('people')->count(), 3);
+		$this->assertEquals($this->builder->table('people')->count(), 3);
 
-    }
+	}
 
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,20 +2,17 @@
 namespace Pecee\Pixie;
 
 use Mockery as m;
+use Pecee\Pixie\ConnectionAdapters\Mysql;
 use Viocon\Container;
 
 class TestCase extends \PHPUnit_Framework_TestCase {
-    /**
-     * @var Container
-     */
-    protected $container;
+
     protected $mockConnection;
     protected $mockPdo;
     protected $mockPdoStatement;
 
     public function setUp()
     {
-        $this->container = new Container();
 
         $this->mockPdoStatement = $this->getMock(\PDOStatement::class);
 
@@ -68,7 +65,7 @@ class TestCase extends \PHPUnit_Framework_TestCase {
 
         $this->mockConnection = m::mock(Connection::class);
         $this->mockConnection->shouldReceive('getPdoInstance')->andReturn($this->mockPdo);
-        $this->mockConnection->shouldReceive('getAdapter')->andReturn('mysql');
+        $this->mockConnection->shouldReceive('getAdapter')->andReturn(new Mysql());
         $this->mockConnection->shouldReceive('getAdapterConfig')->andReturn(array('prefix' => 'cb_'));
         $this->mockConnection->shouldReceive('getContainer')->andReturn($this->container);
         $this->mockConnection->shouldReceive('getEventHandler')->andReturn($eventHandler);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -68,7 +68,6 @@ class TestCase extends \PHPUnit_Framework_TestCase {
 		$this->mockConnection->shouldReceive('getPdoInstance')->andReturn($this->mockPdo);
 		$this->mockConnection->shouldReceive('getAdapter')->andReturn(new Mysql());
 		$this->mockConnection->shouldReceive('getAdapterConfig')->andReturn(array('prefix' => 'cb_'));
-		$this->mockConnection->shouldReceive('getContainer')->andReturn($this->container);
 		$this->mockConnection->shouldReceive('getEventHandler')->andReturn($eventHandler);
 	}
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Pecee\Pixie;
 
 use Mockery as m;
@@ -7,86 +8,83 @@ use Viocon\Container;
 
 class TestCase extends \PHPUnit_Framework_TestCase {
 
-    protected $mockConnection;
-    protected $mockPdo;
-    protected $mockPdoStatement;
+	protected $mockConnection;
+	protected $mockPdo;
+	protected $mockPdoStatement;
 
-    public function setUp()
-    {
+	public function setUp() {
 
-        $this->mockPdoStatement = $this->getMock(\PDOStatement::class);
+		$this->mockPdoStatement = $this->getMock(\PDOStatement::class);
 
-        $mockPdoStatement = & $this->mockPdoStatement;
+		$mockPdoStatement = &$this->mockPdoStatement;
 
-        $mockPdoStatement->bindings = array();
+		$mockPdoStatement->bindings = array();
 
-        $this->mockPdoStatement
-            ->expects($this->any())
-            ->method('bindValue')
-            ->will($this->returnCallback(function ($parameter, $value, $dataType) use ($mockPdoStatement) {
-                $mockPdoStatement->bindings[] = array($value, $dataType);
-            }));
+		$this->mockPdoStatement
+			->expects($this->any())
+			->method('bindValue')
+			->will($this->returnCallback(function ($parameter, $value, $dataType) use ($mockPdoStatement) {
+				$mockPdoStatement->bindings[] = array($value, $dataType);
+			}));
 
-        $this->mockPdoStatement
-            ->expects($this->any())
-            ->method('execute')
-            ->will($this->returnCallback(function($bindings = null) use ($mockPdoStatement) {
-                if ($bindings) {
-                    $mockPdoStatement->bindings = $bindings;
-                }
-            }));
+		$this->mockPdoStatement
+			->expects($this->any())
+			->method('execute')
+			->will($this->returnCallback(function ($bindings = null) use ($mockPdoStatement) {
+				if ($bindings) {
+					$mockPdoStatement->bindings = $bindings;
+				}
+			}));
 
 
-        $this->mockPdoStatement
-            ->expects($this->any())
-            ->method('fetchAll')
-            ->will($this->returnCallback(function() use ($mockPdoStatement){
-                return array($mockPdoStatement->sql, $mockPdoStatement->bindings);
-            }));
+		$this->mockPdoStatement
+			->expects($this->any())
+			->method('fetchAll')
+			->will($this->returnCallback(function () use ($mockPdoStatement) {
+				return array($mockPdoStatement->sql, $mockPdoStatement->bindings);
+			}));
 
-        $this->mockPdo = $this->getMock(MockPdo::class, array('prepare', 'setAttribute', 'quote', 'lastInsertId'));
+		$this->mockPdo = $this->getMock(MockPdo::class, array('prepare', 'setAttribute', 'quote', 'lastInsertId'));
 
-        $this->mockPdo
-            ->expects($this->any())
-            ->method('prepare')
-            ->will($this->returnCallback(function($sql) use ($mockPdoStatement){
-                $mockPdoStatement->sql = $sql;
-                return $mockPdoStatement;
-            }));
+		$this->mockPdo
+			->expects($this->any())
+			->method('prepare')
+			->will($this->returnCallback(function ($sql) use ($mockPdoStatement) {
+				$mockPdoStatement->sql = $sql;
 
-        $this->mockPdo
-            ->expects($this->any())
-            ->method('quote')
-            ->will($this->returnCallback(function($value){
-                return "'$value'";
-            }));
+				return $mockPdoStatement;
+			}));
 
-        $eventHandler = new EventHandler();
+		$this->mockPdo
+			->expects($this->any())
+			->method('quote')
+			->will($this->returnCallback(function ($value) {
+				return "'$value'";
+			}));
 
-        $this->mockConnection = m::mock(Connection::class);
-        $this->mockConnection->shouldReceive('getPdoInstance')->andReturn($this->mockPdo);
-        $this->mockConnection->shouldReceive('getAdapter')->andReturn(new Mysql());
-        $this->mockConnection->shouldReceive('getAdapterConfig')->andReturn(array('prefix' => 'cb_'));
-        $this->mockConnection->shouldReceive('getContainer')->andReturn($this->container);
-        $this->mockConnection->shouldReceive('getEventHandler')->andReturn($eventHandler);
-    }
+		$eventHandler = new EventHandler();
 
-    public function tearDown()
-    {
-        m::close();
-    }
+		$this->mockConnection = m::mock(Connection::class);
+		$this->mockConnection->shouldReceive('getPdoInstance')->andReturn($this->mockPdo);
+		$this->mockConnection->shouldReceive('getAdapter')->andReturn(new Mysql());
+		$this->mockConnection->shouldReceive('getAdapterConfig')->andReturn(array('prefix' => 'cb_'));
+		$this->mockConnection->shouldReceive('getContainer')->andReturn($this->container);
+		$this->mockConnection->shouldReceive('getEventHandler')->andReturn($eventHandler);
+	}
 
-    public function callbackMock()
-    {
-        $args = func_get_args();
-        return count($args) == 1 ? $args[0] : $args;
-    }
+	public function tearDown() {
+		m::close();
+	}
+
+	public function callbackMock() {
+		$args = func_get_args();
+
+		return count($args) == 1 ? $args[0] : $args;
+	}
 }
 
-class MockPdo extends \PDO
-{
-    public function __construct()
-    {
+class MockPdo extends \PDO {
+	public function __construct() {
 
-    }
+	}
 }


### PR DESCRIPTION
- [!!!] Removed `usmanhalalit/viocon` composer dependency (Container support) to increase library performance.
- [!!!] Changed parameter order on `alias` method in `QueryBuilderHandler`.
- [!!!] Removed deprecated `prefix` method.
- Added support for nested transactions.
- Batch insert now uses transactions correctly.
- Fixed where unable to insert params with `NULL` value.
- Changed parameter-binding so data-type are now parsed by PDO.
- Alias will now automatically determine table-name if missing parameter.
- Added event-type constants to `EventHandler` class.
- Updated return-types and PHP Docs.
- Optimisations and bugfixes.
- Updated documentation.

## Release note
This version contains breaking changes. Before upgrading, please read the read the release notes carefully.

**Removed `usmanhalalit/viocon` composer dependency (Container support) to increase library performance.**
If you are currently using containers in your projects, please note that this feature is no longer supported in the `pecee-pixie` library. To create custom connection-adapter, you need to inherit the `IConnectionAdapter` interface and use it as a driver on your `Connection` object instead.

**Removed deprecated `prefix` method.**
The deprecated  method `$qb->prefix($table, $alias)` has been removed. Please change all references to `$qb->alias($alias, $table);`.

**Changed parameter order on `alias` method in `QueryBuilderHandler`.**
`$qb->alias($alias)` no longer requires you to enter `$table` - that argument has been moved to the end of the method. If no argument exists, `pecee-pixie` will try to determine the table from any `table()` calls. Please change all references to `$qb->alias($alias, $table);`.