### PR TITLE
Version 4.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This library is stable, maintained and are used by sites around the world (check
 **Requirements:**
 - PHP version 7.1 or higher is required for pecee-pixie version 4.x and above. Versions prior to 4.x are available [here](https://github.com/skipperbent/pixie).
 
-### Features
+**Features:**
 
 - Improved sub-queries.
 - Custom prefix/aliases for tables (prefix.`table`).
@@ -68,7 +68,7 @@ $queryBuilder = (new \Pecee\Pixie\Connection('mysql', $config))->getQueryBuilder
 
 **Simple query:**
 
-Get user id with id of `3`. Returns `null` when no match.
+Get user with the id of `3`. Returns `null` when no match.
 
 ```php
 $user = $queryBuilder
@@ -78,28 +78,15 @@ $user = $queryBuilder
 
 **Full queries:**
 
-Get all users with blue hair.
+Get all users with blue or red hair.
 
 ```php
 $users = $queryBuilder
             ->table('users')
             ->where('hair_color', '=', 'blue')
+            ->orWhere('hair_color', '=', 'red')
             ->get();
 ```
-
-**Query events:**
-
-After the code below, every time a select query occurs on `users` table, it will add this where criteria, so banned users don't get access.
-
-```php
-$queryBuilder->registerEvent('before-select', 'users', function(EventArguments $arguments)
-{
-    $arguments
-        ->getQueryBuilder()
-        ->where('status', '!=', 'banned');
-});
-```
-There are many advanced options which are documented below. Sold? Let's [install](#installation).
 
 ### Table of Contents
 
@@ -303,7 +290,8 @@ FROM `table1` AS `foo1`
 INNER JOIN `cb_table2` ON `cb_table2`.`person_id` = `cb_foo1`.`id`
 ```
 
-**Note:** You can always remove a table from a query by calling the `table` method with no arguments like this `$queryBuilder->table()`.
+**NOTE:**
+You can always remove a table from a query by calling the `table` method with no arguments like this `$queryBuilder->table()`.
 
 #### Get easily
 

--- a/README.md
+++ b/README.md
@@ -39,22 +39,34 @@ Most importantly this project is used on many live-sites and maintained.
 require 'vendor/autoload.php';
 
 // Create a connection, once only.
-$config = array(
-            'driver'    => 'mysql', // Db driver or IConnectionAdapter class
-            'host'      => 'localhost',
-            'database'  => 'your-database',
-            'username'  => 'root',
-            'password'  => 'your-password',
-            'charset'   => 'utf8', // Optional
-            'collation' => 'utf8_unicode_ci', // Optional
-            'prefix'    => 'cb_', // Table prefix, optional
-            'options'   => array( // PDO constructor options, optional
-                PDO::ATTR_TIMEOUT => 5,
-                PDO::ATTR_EMULATE_PREPARES => false,
-            ),
-        );
+$config =
+[
+    // Name of database driver or IConnectionAdapter class
+    'driver'    => 'mysql',
+    'host'      => 'localhost',
+    'database'  => 'your-database',
+    'username'  => 'root',
+    'password'  => 'your-password',
 
-$queryBuilder = (new \Pecee\Pixie\Connection('mysql', $config))->getQueryBuilder();
+    // Optional
+    'charset'   => 'utf8',
+
+    // Optional
+    'collation' => 'utf8_unicode_ci',
+
+    // Table prefix, optional
+    'prefix'    => 'cb_',
+
+    // PDO constructor options, optional
+    'options'   => [
+        PDO::ATTR_TIMEOUT => 5,
+        PDO::ATTR_EMULATE_PREPARES => false,
+    ],
+];
+
+$queryBuilder =
+    (new \Pecee\Pixie\Connection('mysql', $config))
+    ->getQueryBuilder();
 ```
 
 **Simple query:**
@@ -194,20 +206,20 @@ You can specify the driver during connection and the associated configuration wh
 require 'vendor/autoload.php';
 
 $config = [
-    'driver'    => 'mysql', // Db driver
+    'driver'    => 'mysql',
     'host'      => 'localhost',
     'database'  => 'your-database',
     'username'  => 'root',
     'password'  => 'your-password',
-    'charset'   => 'utf8', // Optional
-    'collation' => 'utf8_unicode_ci', // Optional
-    'prefix'    => 'cb_', // Table prefix, optional
+    'charset'   => 'utf8',
+    'collation' => 'utf8_unicode_ci',
+    'prefix'    => '',
 ];
 
 // Creates new connection
 $connection = new \Pecee\Pixie\Connection('mysql', $config);
 
-// Get the query-builder object
+// Get the query-builder object which will initialize the database connection
 $queryBuilder = $connection->getQueryBuilder();
 
 // Run query
@@ -218,6 +230,10 @@ $person = $queryBuilder
 ```
 
 `$connection` here is optional, if not given it will always associate itself to the first connection, but it can be useful when you have multiple database connections.
+
+**NOTE:**
+Calling the `getQueryBuilder` method will automatically make a connection to the database, if none has already established.
+If you want to access the `Pdo` instance directly from the `Connection` class, make sure to call `$connection->connect();` to establish a connection to the database.
 
 ### SQLite and PostgreSQL config example
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This library is stable, maintained and are used by sites around the world (check
 
 Most importantly this project is used on many live-sites and maintained.
 
-## Example
+### Examples
 ```php
 // Make sure you have Composer's autoload file included
 require 'vendor/autoload.php';
@@ -88,7 +88,9 @@ $users = $queryBuilder
             ->get();
 ```
 
-### Table of Contents
+___
+
+## Table of Contents
 
  - [Installation](#installation)
  - [Feedback and development](#feedback-and-development)

--- a/README.md
+++ b/README.md
@@ -5,12 +5,10 @@ Pixie supports MySQL, SQLite and PostgreSQL will handle all your query sanitizat
 
 The syntax is similar to Laravel's query builder "Eloquent", but with less overhead.
 
-This library is stable, maintained and are used by sites around the world (check credits).
+This library is stable, maintained and are used by sites around the world (check the [credits](#credits)).
 
 **Requirements:**
-- PHP version 7.1 or higher is required for pecee-pixie version 4.x and above.
-
-Versions prior to 4.x are available [here](https://github.com/skipperbent/pixie).
+- PHP version 7.1 or higher is required for pecee-pixie version 4.x and above. Versions prior to 4.x are available [here](https://github.com/skipperbent/pixie).
 
 ### Features
 
@@ -19,6 +17,7 @@ Versions prior to 4.x are available [here](https://github.com/skipperbent/pixie)
 - Support for not defining table and/or removing defined table.
 - Better handling of `Raw` objects in `where` statements.
 - Union queries.
+- Better connection handling.
 - Performance optimisations.
 - Tons of bug fixes.
 - Much more...
@@ -64,32 +63,35 @@ $config =
     ],
 ];
 
-$queryBuilder =
-    (new \Pecee\Pixie\Connection('mysql', $config))
-    ->getQueryBuilder();
+$queryBuilder = (new \Pecee\Pixie\Connection('mysql', $config))->getQueryBuilder();
 ```
 
 **Simple query:**
 
-The query below returns the row where id = 3, null if no rows.
-```PHP
-$row = $queryBuilder->table('my_table')->find(3);
+Get user id with id of `3`. Returns `null` when no match.
+
+```php
+$user = $queryBuilder
+            ->table('users')
+            ->find(3);
 ```
 
 **Full queries:**
 
-```PHP
-$query = $queryBuilder->table('my_table')->where('name', '=', 'Sana');
+Get all users with blue hair.
 
-// Get result
-$query->get();
+```php
+$users = $queryBuilder
+            ->table('users')
+            ->where('hair_color', '=', 'blue')
+            ->get();
 ```
 
 **Query events:**
 
 After the code below, every time a select query occurs on `users` table, it will add this where criteria, so banned users don't get access.
 
-```PHP
+```php
 $queryBuilder->registerEvent('before-select', 'users', function(EventArguments $arguments)
 {
     $arguments
@@ -301,7 +303,7 @@ FROM `table1` AS `foo1`
 INNER JOIN `cb_table2` ON `cb_table2`.`person_id` = `cb_foo1`.`id`
 ```
 
-**Note:** You can always remove a table from a query by calling the `table` method with no arguments like this `$qb->table()`.
+**Note:** You can always remove a table from a query by calling the `table` method with no arguments like this `$queryBuilder->table()`.
 
 #### Get easily
 
@@ -950,7 +952,7 @@ You can also retrieve the query-object from the last executed query.
 **Example:**
 
 ```php
-$queryString = $qb->getLastQuery()->getRawSql();
+$queryString = $queryBuilder->getLastQuery()->getRawSql();
 ```
 
 ### Sub-queries and nested queries

--- a/src/Pecee/Pixie/Connection.php
+++ b/src/Pecee/Pixie/Connection.php
@@ -61,8 +61,7 @@ class Connection
 
         $this
             ->setAdapter($adapter)
-            ->setAdapterConfig($adapterConfig)
-            ->connect();
+            ->setAdapterConfig($adapterConfig);
 
         // Create event dependency
         $this->eventHandler = new EventHandler();
@@ -81,12 +80,16 @@ class Connection
     }
 
     /**
-     * Create the connection adapter
+     * Create the connection adapter and connect to database
+     * @return static
      */
-    public function connect(): void
+    public function connect(): self
     {
-        // Build a database connection if we don't have one connected
+        if ($this->pdoInstance !== null) {
+            return $this;
+        }
 
+        // Build a database connection if we don't have one connected
         $pdo = $this->getAdapter()->connect($this->getAdapterConfig());
         $this->setPdoInstance($pdo);
 
@@ -94,6 +97,8 @@ class Connection
         if (static::$storedConnection === null) {
             static::$storedConnection = $this;
         }
+
+        return $this;
     }
 
     /**

--- a/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -92,6 +92,9 @@ class QueryBuilderHandler implements IQueryBuilderHandler
             throw new ConnectionException('No database connection found.', 404);
         }
 
+        // Connect to database
+        $this->connection->connect();
+
         $adapterConfig = $this->connection->getAdapterConfig();
 
         if (isset($adapterConfig['prefix']) === true) {

--- a/tests/Pecee/Pixie/ConnectionTest.php
+++ b/tests/Pecee/Pixie/ConnectionTest.php
@@ -38,6 +38,7 @@ class ConnectionTest extends TestCase
 
     public function testConnection()
     {
+        $this->connection->connect();
         $this->assertEquals($this->mockPdo, $this->connection->getPdoInstance());
         $this->assertInstanceOf(\PDO::class, $this->connection->getPdoInstance());
         $this->assertInstanceOf(IConnectionAdapter::class, $this->connection->getAdapter());

--- a/tests/Pecee/Pixie/CustomExceptionsTest.php
+++ b/tests/Pecee/Pixie/CustomExceptionsTest.php
@@ -41,7 +41,7 @@ class CustomExceptionsTest extends TestCase
 
         // test error code 2002
         try {
-            new \Pecee\Pixie\Connection('mysql', [
+            (new \Pecee\Pixie\Connection('mysql', [
                 'driver'    => 'mysql',
                 'host'      => '0.2.3.4',
                 'database'  => 'test',
@@ -50,14 +50,14 @@ class CustomExceptionsTest extends TestCase
                 'charset'   => 'utf8mb4', // Optional
                 'collation' => 'utf8mb4_unicode_ci', // Optional
                 'prefix'    => '', // Table prefix, optional
-            ]);
+            ]))->connect();
         } catch (\Exception $e) {
             $this->validateException($e, ConnectionException::class, 2002);
         }
 
         // test error code 1045
         try {
-            new \Pecee\Pixie\Connection('mysql', [
+            (new \Pecee\Pixie\Connection('mysql', [
                 'driver'    => 'mysql',
                 'host'      => '127.0.0.1',
                 'database'  => 'test',
@@ -66,14 +66,14 @@ class CustomExceptionsTest extends TestCase
                 'charset'   => 'utf8mb4', // Optional
                 'collation' => 'utf8mb4_unicode_ci', // Optional
                 'prefix'    => '', // Table prefix, optional
-            ]);
+            ]))->connect();
         } catch (\Exception $e) {
             $this->validateException($e, ConnectionException::class, 1045);
         }
 
         // test error code 1044
         try {
-            new \Pecee\Pixie\Connection('mysql', [
+            (new \Pecee\Pixie\Connection('mysql', [
                 'driver'    => 'mysql',
                 'host'      => '127.0.0.1',
                 'database'  => 'root',
@@ -82,7 +82,7 @@ class CustomExceptionsTest extends TestCase
                 'charset'   => 'utf8mb4', // Optional
                 'collation' => 'utf8mb4_unicode_ci', // Optional
                 'prefix'    => '', // Table prefix, optional
-            ]);
+            ]))->connect();
         } catch (\Exception $e) {
             $this->validateException($e, ConnectionException::class, 1044);
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -103,6 +103,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $this->mockConnection->shouldReceive('getAdapterConfig')->andReturn(['prefix' => 'cb_']);
         $this->mockConnection->shouldReceive('getEventHandler')->andReturn($eventHandler);
         $this->mockConnection->shouldReceive('setLastQuery');
+        $this->mockConnection->shouldReceive('connect')->andReturn($this->mockConnection);
         $this->builder = new QueryBuilderHandler($this->mockConnection);
     }
 


### PR DESCRIPTION
- Feature: added better database connection handling.
- Updated unit-tests.
- Updated documentation.

## Release notes
Added better control for database connections. A connection to the database will now only be established when a new instance of `QueryBuilderHandler` is created or when `$connection->connect();` has been called manually.

This will ensure that projects that sets the connection in the bootstrap, won't connect to the database unless a query has been created or if the `connect()` method has been called has been called specifically.

**Example:**

This will no longer automatically establish a database connection:

```php
$connection = (new \Pecee\Pixie\Connection('mysql', $config));
```

Unless `$connection->connect()` or `$connection->getQueryBuilder()` or `new QueryBuilderHandler()` is called. 