### PR TITLE
Version 4.8.1

### DIFF
--- a/src/Pecee/Pixie/Connection.php
+++ b/src/Pecee/Pixie/Connection.php
@@ -65,6 +65,8 @@ class Connection
 
         // Create event dependency
         $this->eventHandler = new EventHandler();
+
+        static::$storedConnection = $this;
     }
 
     /**
@@ -90,13 +92,7 @@ class Connection
         }
 
         // Build a database connection if we don't have one connected
-        $pdo = $this->getAdapter()->connect($this->getAdapterConfig());
-        $this->setPdoInstance($pdo);
-
-        // Preserve the first database connection with a static property
-        if (static::$storedConnection === null) {
-            static::$storedConnection = $this;
-        }
+        $this->setPdoInstance($this->getAdapter()->connect($this->getAdapterConfig()));
 
         return $this;
     }


### PR DESCRIPTION
- Fixed events not firing as `$storedConnection` was overwritten in `Connection` class.