### PR TITLE
 Added JOIN USING functionality (issue: #85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,8 +654,7 @@ $queryBuilder
         $table
             ->on('another_table.person_id', '=', 'my_table.id')
             ->on('another_table.person_id2', '=', 'my_table.id2')
-            ->orOn('another_table.age', '>', $queryBuilder->raw(1))
-            ->orUsing('another_table.gender', 'person_id');
+            ->orOn('another_table.age', '>', $queryBuilder->raw(1));
     })
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ This library is stable, maintained and are used by sites around the world (check
 
 **Including all the original features like:**
 
-- Query Events
-- Nested Criteria
-- Sub Queries
-- Nested Queries
-- Multiple Database Connections.
+- Query events
+- Nested criteria
+- Sub queries
+- Nested queries
+- Multiple database connections.
 
 Most importantly this project is used on many live-sites and maintained.
 
@@ -124,6 +124,7 @@ ___
  - [Having](#having)
  - [Limit and offset](#limit-and-offset)
  - [Join](#join)
+    - [Join USING syntax](#join-using-syntax)
     - [Multiple join criteria](#multiple-join-criteria)
  - [Unions](#unions)
  - [Raw query](#raw-query)
@@ -622,7 +623,27 @@ $queryBuilder
     ->join('another_table', 'another_table.person_id', '=', 'my_table.id', 'FULL OUTER')
 ```
 
-#### Multiple Join Criteria
+#### Join USING syntax
+
+The `JOIN USING` syntax allows you to easily map two identical identifiers to one, which can be helpful on large queries.
+
+Example:
+
+```php
+$queryBuilder
+    ->table('user')
+    ->join('user_data', 'user_data.user_id', '=', 'user.user_id');
+```
+
+Can be simplified to:
+
+```php
+$queryBuilder
+    ->table('user')
+    ->joinUsing('user_data', 'user_id');
+```
+
+#### Multiple join criteria
 
 If you need more than one criterion to join a table then pass a closure as second parameter.
 
@@ -630,9 +651,11 @@ If you need more than one criterion to join a table then pass a closure as secon
 $queryBuilder
     ->join('another_table', function($table)
     {
-        $table->on('another_table.person_id', '=', 'my_table.id');
-        $table->on('another_table.person_id2', '=', 'my_table.id2');
-        $table->orOn('another_table.age', '>', $queryBuilder->raw(1));
+        $table
+            ->on('another_table.person_id', '=', 'my_table.id')
+            ->on('another_table.person_id2', '=', 'my_table.id2')
+            ->orOn('another_table.age', '>', $queryBuilder->raw(1))
+            ->orUsing('another_table.gender', 'person_id');
     })
 ```
 

--- a/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -79,12 +79,8 @@ abstract class BaseAdapter
 
         foreach ($statements as $i => $statement) {
 
-            $key = $statement['key'];
-
-            $key = $this->wrapSanitizer($key);
-
-            if ($statement['key'] instanceof Raw) {
-                $bindings[] = $statement['key']->getBindings();
+            if ($i === 0 && isset($statement['condition'])) {
+                $criteria[] = $statement['condition'];
             }
 
             $joiner = ($i === 0) ? trim(str_ireplace(['and', 'or'], '', $statement['joiner'])) : $statement['joiner'];
@@ -96,6 +92,14 @@ abstract class BaseAdapter
             if (isset($statement['columns']) === true) {
                 $criteria[] = sprintf('(%s)', $this->arrayStr((array)$statement['columns']));
                 continue;
+            }
+
+            $key = $statement['key'];
+
+            $key = $this->wrapSanitizer($key);
+
+            if ($statement['key'] instanceof Raw) {
+                $bindings[] = $statement['key']->getBindings();
             }
 
             $value = $statement['value'];
@@ -242,7 +246,7 @@ abstract class BaseAdapter
                 strtoupper($joinArr['type']),
                 'JOIN',
                 $table,
-                $joinArr['condition'],
+
                 $joinBuilder->getQuery('criteriaOnly', false)->getSql(),
             ];
 

--- a/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -45,7 +45,7 @@ abstract class BaseAdapter
      *
      * @return string
      */
-    protected function arrayStr(array $pieces, $glue = ',', $wrapSanitizer = true): string
+    protected function arrayStr(array $pieces, string $glue = ',', bool $wrapSanitizer = true): string
     {
         $str = '';
         foreach ($pieces as $key => $piece) {
@@ -72,21 +72,33 @@ abstract class BaseAdapter
      * @throws Exception
      * @return array
      */
-    protected function buildCriteria(array $statements, $bindValues = true): array
+    protected function buildCriteria(array $statements, bool $bindValues = true): array
     {
-        $criteria = '';
+        $criteria = [];
         $bindings = [[]];
 
-        foreach ($statements as $statement) {
+        foreach ($statements as $i => $statement) {
 
             $key = $statement['key'];
 
             $key = $this->wrapSanitizer($key);
-            $value = $statement['value'];
 
             if ($statement['key'] instanceof Raw) {
                 $bindings[] = $statement['key']->getBindings();
             }
+
+            $joiner = ($i === 0) ? trim(str_ireplace(['and', 'or'], '', $statement['joiner'])) : $statement['joiner'];
+
+            if ($joiner !== '') {
+                $criteria[] = $joiner;
+            }
+
+            if (isset($statement['columns']) === true) {
+                $criteria[] = sprintf('(%s)', $this->arrayStr((array)$statement['columns']));
+                continue;
+            }
+
+            $value = $statement['value'];
 
             if ($value === null && $key instanceof \Closure) {
 
@@ -107,7 +119,7 @@ abstract class BaseAdapter
                 $bindings[] = $queryObject->getBindings();
 
                 // Append the sql we get from the nestedCriteria object
-                $criteria .= $statement['joiner'] . ' (' . $queryObject->getSql() . ') ';
+                $criteria[] = "({$queryObject->getSql()})";
 
                 continue;
             }
@@ -115,65 +127,59 @@ abstract class BaseAdapter
             if (\is_array($value) === true) {
 
                 // Where in or between like query
-                $criteria .= $statement['joiner'] . ' ' . $key . ' ' . $statement['operator'];
+                $criteria[] = "$key {$statement['operator']}";
 
                 if ($statement['operator'] === 'BETWEEN') {
                     $bindings[] = $statement['value'];
-                    $criteria .= ' ? AND ? ';
+                    $criteria[] = '? AND ?';
                     continue;
                 }
 
                 $valuePlaceholder = '';
+
                 foreach ((array)$statement['value'] as $subValue) {
                     $valuePlaceholder .= '?, ';
                     $bindings[] = [$subValue];
                 }
 
                 $valuePlaceholder = trim($valuePlaceholder, ', ');
-                $criteria .= ' (' . $valuePlaceholder . ') ';
+                $criteria[] = "($valuePlaceholder)";
 
                 continue;
             }
 
-            if ($value instanceof Raw) {
-                $criteria .= "{$statement['joiner']} {$key} {$statement['operator']} $value ";
-                continue;
-            }
+            if ($bindValues === false || $value instanceof Raw) {
 
-            // Usual where like criteria
-            if ($bindValues === false) {
-
-                // Specially for joins - we are not binding values, lets sanitize then
-                $value = $this->wrapSanitizer($value);
-                $criteria .= $statement['joiner'] . ' ' . $key . ' ' . $statement['operator'] . ' ' . $value . ' ';
-
+                // Usual where like criteria specially for joins - we are not binding values, lets sanitize then
+                $value = ($bindValues === false) ? $this->wrapSanitizer($value) : $value;
+                $criteria[] = "{$key} {$statement['operator']} $value";
                 continue;
             }
 
             if ($statement['key'] instanceof Raw) {
 
                 if ($statement['operator'] !== null) {
-                    $criteria .= "{$statement['joiner']} {$key} {$statement['operator']} ? ";
-
+                    $criteria[] = "{$key} {$statement['operator']} ?";
                     $bindings[] = [$value];
                     continue;
                 }
 
-                $criteria .= $statement['joiner'] . ' ' . $key . ' ';
+                $criteria[] = $key;
                 continue;
 
             }
 
             // WHERE
-            $valuePlaceholder = '?';
             $bindings[] = [$value];
-            $criteria .= $statement['joiner'] . ' ' . $key . ' ' . $statement['operator'] . ' ' . $valuePlaceholder . ' ';
+            $criteria[] = "$key {$statement['operator']} ?";
         }
 
         // Clear all white spaces, and, or from beginning and white spaces from ending
-        $criteria = preg_replace('/^(\s?AND ?|\s?OR ?)|\s$/i', '', $criteria);
 
-        return [$criteria, array_merge(...$bindings)];
+        return [
+            implode(' ', $criteria),
+            array_merge(...$bindings),
+        ];
     }
 
     /**
@@ -236,7 +242,7 @@ abstract class BaseAdapter
                 strtoupper($joinArr['type']),
                 'JOIN',
                 $table,
-                'ON',
+                $joinArr['condition'],
                 $joinBuilder->getQuery('criteriaOnly', false)->getSql(),
             ];
 

--- a/src/Pecee/Pixie/QueryBuilder/JoinBuilder.php
+++ b/src/Pecee/Pixie/QueryBuilder/JoinBuilder.php
@@ -22,10 +22,11 @@ class JoinBuilder extends QueryBuilderHandler
     public function on($key, $operator, $value, $joiner = 'AND'): self
     {
         $this->statements['criteria'][] = [
-            'key'      => $this->addTablePrefix($key),
-            'operator' => $operator,
-            'value'    => $this->addTablePrefix($value),
-            'joiner'   => $joiner,
+            'key'       => $this->addTablePrefix($key),
+            'operator'  => $operator,
+            'value'     => $this->addTablePrefix($value),
+            'joiner'    => $joiner,
+            'condition' => 'ON',
         ];
 
         return $this;
@@ -34,36 +35,17 @@ class JoinBuilder extends QueryBuilderHandler
     /**
      * Add join with USING syntax
      *
-     * @param string|Raw|\Closure $table
      * @param array $columns
-     * @param string $joiner
      * @return static
      */
-    public function using($table, array $columns, $joiner = 'AND'): self
+    public function using(array $columns): self
     {
         $this->statements['criteria'][] = [
-            'key'     => $this->addTablePrefix($table),
             'columns' => $this->addTablePrefix($columns),
-            'joiner'  => $joiner,
+            'joiner'  => 'AND USING',
         ];
 
         return $this;
-    }
-
-    /**
-     * Add OR join with USING syntax
-     *
-     * @param string|Raw|\Closure $table
-     * @param array $columns
-     * @return static
-     */
-    public function orUsing($table, array $columns): self
-    {
-        return $this->using(
-            $this->addTablePrefix($table),
-            $this->addTablePrefix($columns),
-            'OR'
-        );
     }
 
     /**

--- a/src/Pecee/Pixie/QueryBuilder/JoinBuilder.php
+++ b/src/Pecee/Pixie/QueryBuilder/JoinBuilder.php
@@ -10,43 +10,74 @@ namespace Pecee\Pixie\QueryBuilder;
 class JoinBuilder extends QueryBuilderHandler
 {
     /**
+     * Add join
+     *
      * @param string|Raw|\Closure $key
      * @param string|Raw|\Closure $operator
      * @param string|Raw|\Closure $value
-     *
-     * @return static
-     */
-    public function on($key, $operator, $value)
-    {
-        return $this->joinHandler($key, $operator, $value);
-    }
-
-    /**
-     * @param string|Raw|\Closure $key
-     * @param string|Raw|\Closure $operator
-     * @param string|Raw|\Closure $value
-     *
-     * @return static
-     */
-    public function orOn($key, $operator, $value)
-    {
-        return $this->joinHandler($key, $operator, $value, 'OR');
-    }
-
-    /**
-     * @param string|Raw|\Closure $key
-     * @param string|Raw|\Closure|null $operator
-     * @param string|Raw|\Closure|null $value
      * @param string $joiner
      *
      * @return static
      */
-    protected function joinHandler($key, $operator = null, $value = null, $joiner = 'AND')
+    public function on($key, $operator, $value, $joiner = 'AND'): self
     {
-        $key = $this->addTablePrefix($key);
-        $value = $this->addTablePrefix($value);
-        $this->statements['criteria'][] = compact('key', 'operator', 'value', 'joiner');
+        $this->statements['criteria'][] = [
+            'key'      => $this->addTablePrefix($key),
+            'operator' => $operator,
+            'value'    => $this->addTablePrefix($value),
+            'joiner'   => $joiner,
+        ];
 
         return $this;
     }
+
+    /**
+     * Add join with USING syntax
+     *
+     * @param string|Raw|\Closure $table
+     * @param array $columns
+     * @param string $joiner
+     * @return static
+     */
+    public function using($table, array $columns, $joiner = 'AND'): self
+    {
+        $this->statements['criteria'][] = [
+            'key'     => $this->addTablePrefix($table),
+            'columns' => $this->addTablePrefix($columns),
+            'joiner'  => $joiner,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * Add OR join with USING syntax
+     *
+     * @param string|Raw|\Closure $table
+     * @param array $columns
+     * @return static
+     */
+    public function orUsing($table, array $columns): self
+    {
+        return $this->using(
+            $this->addTablePrefix($table),
+            $this->addTablePrefix($columns),
+            'OR'
+        );
+    }
+
+    /**
+     * Add OR ON join
+     *
+     * @param string|Raw|\Closure $key
+     * @param string|Raw|\Closure $operator
+     * @param string|Raw|\Closure $value
+     *
+     * @return static
+     */
+    public function orOn($key, $operator, $value): self
+    {
+        return $this->on($key, $operator, $value, 'OR');
+    }
+
 }

--- a/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -919,7 +919,6 @@ class QueryBuilderHandler implements IQueryBuilderHandler
             'type'        => $type,
             'table'       => $table,
             'joinBuilder' => $joinBuilder,
-            'condition'   => 'ON',
         ];
 
         return $this;
@@ -988,7 +987,6 @@ class QueryBuilderHandler implements IQueryBuilderHandler
         }
 
         // Otherwise insert one by one...
-
         foreach ($data as $subData) {
             $insertIds[] = $this->doInsert($subData, $type);
         }
@@ -1059,7 +1057,7 @@ class QueryBuilderHandler implements IQueryBuilderHandler
         }
 
         $joinBuilder = new JoinBuilder($this->connection);
-        $joinBuilder->using($table, $fields);
+        $joinBuilder->using($fields);
 
         $table = $this->addTablePrefix($table, false);
 
@@ -1067,7 +1065,6 @@ class QueryBuilderHandler implements IQueryBuilderHandler
             'type'        => $joinType,
             'table'       => $table,
             'joinBuilder' => $joinBuilder,
-            'condition'   => 'USING',
         ];
 
         return $this;

--- a/tests/Pecee/Pixie/QueryBuilderBehaviorTest.php
+++ b/tests/Pecee/Pixie/QueryBuilderBehaviorTest.php
@@ -3,6 +3,7 @@
 namespace Pecee\Pixie;
 
 use Pecee\Pixie\Event\EventArguments;
+use Pecee\Pixie\QueryBuilder\JoinBuilder;
 
 /**
  * Class QueryBuilderTest
@@ -358,6 +359,17 @@ class QueryBuilderTest extends TestCase
     {
 
         $query = $this->builder->table('user')->joinUsing('user_data', ['user_id', 'image_id'])->where('user_id', '=', 1);
+
+        $this->assertEquals('SELECT * FROM `cb_user` JOIN `cb_user_data` USING (`user_id`,`image_id`) WHERE `user_id` = 1', $query->getQuery()->getRawSql());
+
+    }
+
+    public function testJoinQueryBuilderUsing()
+    {
+
+        $query = $this->builder->table('user')->join('user_data', function (JoinBuilder $jb) {
+            $jb->using(['user_id', 'image_id']);
+        })->where('user_id', '=', 1);
 
         $this->assertEquals('SELECT * FROM `cb_user` JOIN `cb_user_data` USING (`user_id`,`image_id`) WHERE `user_id` = 1', $query->getQuery()->getRawSql());
 

--- a/tests/Pecee/Pixie/QueryBuilderBehaviorTest.php
+++ b/tests/Pecee/Pixie/QueryBuilderBehaviorTest.php
@@ -19,7 +19,7 @@ class QueryBuilderTest extends TestCase
         $query = $this->builder
             ->table(['table1'])
             ->alias('t1')
-            ->join('table2', 'table2.person_id', '=', 'foo2.id');
+            ->innerJoin('table2', 'table2.person_id', '=', 'foo2.id');
 
         $this->assertEquals('SELECT * FROM `cb_table1` AS `t1` INNER JOIN `cb_table2` ON `cb_table2`.`person_id` = `cb_foo2`.`id`',
             $query->getQuery()->getRawSql());
@@ -239,7 +239,7 @@ class QueryBuilderTest extends TestCase
             ->having('tot', '<', 2)
             ->limit(1)
             ->offset(0)
-            ->join(
+            ->innerJoin(
                 'person_details',
                 'person_details.person_id',
                 '=',
@@ -265,7 +265,7 @@ class QueryBuilderTest extends TestCase
                     $q2->orWhere('value', 'LIKE', '%sana%');
                 });
             })
-            ->join(['person_details', 'a'], 'a.person_id', '=', 'my_table.id')
+            ->innerJoin(['person_details', 'a'], 'a.person_id', '=', 'my_table.id')
             ->leftJoin(['person_details', 'b'], function ($table) use ($builder) {
                 $table->on('b.person_id', '=', 'my_table.id');
                 $table->on('b.deleted', '=', $builder->raw(0));
@@ -351,6 +351,15 @@ class QueryBuilderTest extends TestCase
         $query = $this->builder->whereNull($this->builder->subQuery($subQuery));
 
         $this->assertEquals('SELECT * WHERE (SELECT * FROM `cb_persons` AS `staff`) IS NULL', $query->getQuery()->getRawSql());
+
+    }
+
+    public function testJoinUsing()
+    {
+
+        $query = $this->builder->table('user')->joinUsing('user_data', ['user_id', 'image_id'])->where('user_id', '=', 1);
+
+        $this->assertEquals('SELECT * FROM `cb_user` JOIN `cb_user_data` USING (`user_id`,`image_id`) WHERE `user_id` = 1', $query->getQuery()->getRawSql());
 
     }
 

--- a/tests/Pecee/Pixie/QueryBuilderTest.php
+++ b/tests/Pecee/Pixie/QueryBuilderTest.php
@@ -90,7 +90,7 @@ class QueryBuilder extends TestCase
     {
         $query = $this->builder->table('person')->where('name', [1, null, 3]);
 
-        $this->assertEquals($query->getQuery()->getRawSql(), 'SELECT * FROM `cb_person` WHERE `name` = (1, NULL, 3)');
+        $this->assertEquals('SELECT * FROM `cb_person` WHERE `name` = (1, NULL, 3)', $query->getQuery()->getRawSql());
 
     }
 
@@ -100,7 +100,7 @@ class QueryBuilder extends TestCase
         $qb = $this->builder;
         $query = $qb->table('animals')->whereBetween('created_date', $qb->raw('NOW()'), '27-05-2017');
 
-        $this->assertEquals($query->getQuery()->getRawSql(), 'SELECT * FROM `cb_animals` WHERE `created_date` BETWEEN NOW() AND \'27-05-2017\'');
+        $this->assertEquals('SELECT * FROM `cb_animals` WHERE `created_date` BETWEEN NOW() AND \'27-05-2017\'', $query->getQuery()->getRawSql());
 
     }
 


### PR DESCRIPTION
- Added new `joinUsing` method to `QueryBuilderHandler` class.
- Added new `using` and `orUsing` to `JoinBuilder` class.
- Added support for columns (column1, columns2 etc.) in `buildCriteria` method in `BaseAdapter` class.
- Optimized and simplified `buildCriteria` method in `BaseAdapter` class.
- Fixed behavior for `join` method which was incorrectly using LEFT JOIN as default type.
- Updated documentation to reflect new changes.
- Added unit tests for new `joinUsing` functionality.
- Removed `orUsing` as it's not supported by sql.
- Added unit test for `JoinBuilder`.
- Optimisations.
- Updated readme