### PR TITLE
Fixed aggregate method when table is subquery

### DIFF
--- a/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -171,10 +171,8 @@ class QueryBuilderHandler implements IQueryBuilderHandler
             throw new Exception('No table selected');
         }
 
-        $alias = sprintf('%s_count', $this->getAlias() ?? $this->getTable());
-
         $count = $this
-            ->table($this->subQuery($this, $alias))
+            ->table($this->subQuery($this, 'test'))
             ->select([$this->raw(sprintf('%s(%s) AS `field`', strtoupper($type), $field))])
             ->first();
 

--- a/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -172,7 +172,7 @@ class QueryBuilderHandler implements IQueryBuilderHandler
         }
 
         $count = $this
-            ->table($this->subQuery($this, 'test'))
+            ->table($this->subQuery($this, $this->getAlias() ?? $this->getTable() . '_count'))
             ->select([$this->raw(sprintf('%s(%s) AS `field`', strtoupper($type), $field))])
             ->first();
 
@@ -196,7 +196,14 @@ class QueryBuilderHandler implements IQueryBuilderHandler
      */
     public function getTable(): ?string
     {
-        return isset($this->statements['tables']) === true ? array_values($this->statements['tables'])[0] : null;
+        if(isset($this->statements['tables']) === true) {
+            $table = array_values($this->statements['tables'])[0];
+            if($table instanceof Raw === false) {
+                return $table;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -172,7 +172,7 @@ class QueryBuilderHandler implements IQueryBuilderHandler
         }
 
         $count = $this
-            ->table($this->subQuery($this, $this->getAlias() ?? $this->getTable() . '_count'))
+            ->table($this->subQuery($this, 'count'))
             ->select([$this->raw(sprintf('%s(%s) AS `field`', strtoupper($type), $field))])
             ->first();
 

--- a/tests/Pecee/Pixie/QueryBuilderTest.php
+++ b/tests/Pecee/Pixie/QueryBuilderTest.php
@@ -161,4 +161,13 @@ class QueryBuilder extends TestCase
 
     }
 
+    public function testCountQuery() {
+        $subquery = $this->builder
+            ->newQuery()
+            ->table('foo_table');
+        $oCall = $this->builder->newQuery()->table($this->builder->subQuery($subquery,'q1'))->count();
+
+        die(var_dump($subquery->getLastQuery()->getRawSql()));
+    }
+
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Mockery as m;
 use Pecee\Pixie\ConnectionAdapters\Mysql;
 use Pecee\Pixie\Event\EventHandler;
 use Pecee\Pixie\QueryBuilder\QueryBuilderHandler;
+use Pecee\Pixie\QueryBuilder\QueryObject;
 
 /**
  * Class TestCase


### PR DESCRIPTION
- Fixed `getTable` returning raw-query instead of `null` on subQuery-tables.
- Replaced alias-name in aggregate to generic one.