### PR TITLE
QueryAdapter features

### DIFF
--- a/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -21,6 +21,31 @@ abstract class BaseAdapter
     public const SANITIZER = '`';
 
     /**
+     * @var string
+     */
+    protected const QUERY_PART_JOIN = 'JOIN';
+
+    /**
+     * @var string
+     */
+    protected const QUERY_PART_ORDERBY = 'ORDERBY';
+
+    /**
+     * @var string
+     */
+    protected const QUERY_PART_LIMIT = 'LIMIT';
+
+    /**
+     * @var string
+     */
+    protected const QUERY_PART_OFFSET = 'OFFSET';
+
+    /**
+     * @var string
+     */
+    protected const QUERY_PART_GROUPBY = 'GROUPBY';
+
+    /**
      * @var \Pecee\Pixie\Connection
      */
     protected $connection;
@@ -246,8 +271,7 @@ abstract class BaseAdapter
                 strtoupper($joinArr['type']),
                 'JOIN',
                 $table,
-
-                $joinBuilder->getQuery('criteriaOnly', false)->getSql(),
+                $joinBuilder instanceof QueryBuilderHandler ? $joinBuilder->getQuery('criteriaOnly', false)->getSql() : '',
             ];
 
             $sql = $this->concatenateQuery($sqlArr);
@@ -298,19 +322,40 @@ abstract class BaseAdapter
      * Build delete query
      *
      * @param array $statements
+     * @param array|null $columns
      *
      * @return array
      * @throws Exception
      */
-    public function delete(array $statements): array
+    public function delete(array $statements, array $columns = null): array
     {
         $table = end($statements['tables']);
+
+        $columnsQuery = '';
+
+        if($columns !== null) {
+            foreach($columns as $key => $column) {
+                $columns[$key] = $this->wrapSanitizer($column);
+            }
+
+            $columnsQuery = implode(', ', $columns);
+        }
 
         // WHERE
         [$whereCriteria, $whereBindings] = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
 
-        $sqlArray = ['DELETE FROM', $this->wrapSanitizer($table), $whereCriteria];
-        $sql = $this->concatenateQuery($sqlArray);
+        $sql = $this->concatenateQuery([
+            'DELETE ',
+            $columnsQuery,
+            ' FROM',
+            $this->wrapSanitizer($table),
+            $this->buildQueryPart(static::QUERY_PART_JOIN, $statements),
+            $whereCriteria,
+            $this->buildQueryPart(static::QUERY_PART_GROUPBY, $statements),
+            $this->buildQueryPart(static::QUERY_PART_ORDERBY, $statements),
+            $this->buildQueryPart(static::QUERY_PART_LIMIT, $statements),
+            $this->buildQueryPart(static::QUERY_PART_OFFSET, $statements),
+        ]);
         $bindings = $whereBindings;
 
         return compact('sql', 'bindings');
@@ -492,55 +537,25 @@ abstract class BaseAdapter
             $fromEnabled = true;
         }
 
-        // SELECT
-        $selects = $this->arrayStr($statements['selects'], ', ');
-
         // WHERE
         [$whereCriteria, $whereBindings] = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
-
-        // GROUP BY
-        $groupBys = $this->arrayStr($statements['groupBys'], ', ');
-        if ($groupBys !== '' && isset($statements['groupBys']) === true) {
-            $groupBys = 'GROUP BY ' . $groupBys;
-        }
-
-        // ORDER BY
-        $orderBys = '';
-        if (isset($statements['orderBys']) === true && \is_array($statements['orderBys']) === true) {
-            foreach ($statements['orderBys'] as $orderBy) {
-                $orderBys .= $this->wrapSanitizer($orderBy['field']) . ' ' . $orderBy['type'] . ', ';
-            }
-
-            if ($orderBys = trim($orderBys, ', ')) {
-                $orderBys = 'ORDER BY ' . $orderBys;
-            }
-        }
-
-        // LIMIT AND OFFSET
-        $limit = isset($statements['limit']) ? 'LIMIT ' . $statements['limit'] : '';
-        $offset = isset($statements['offset']) ? 'OFFSET ' . $statements['offset'] : '';
 
         // HAVING
         [$havingCriteria, $havingBindings] = $this->buildCriteriaWithType($statements, 'havings', 'HAVING');
 
-        // JOINS
-        $joinString = $this->buildJoin($statements);
-
-        $sqlArray = [
+        $sql = $this->concatenateQuery([
             'SELECT' . ($hasDistincts === true ? ' DISTINCT' : ''),
-            $selects,
+            $this->arrayStr($statements['selects'], ', '),
             $fromEnabled ? 'FROM' : '',
             $tables,
-            $joinString,
+            $this->buildQueryPart(static::QUERY_PART_JOIN, $statements),
             $whereCriteria,
-            $groupBys,
+            $this->buildQueryPart(static::QUERY_PART_GROUPBY, $statements),
             $havingCriteria,
-            $orderBys,
-            $limit,
-            $offset,
-        ];
-
-        $sql = $this->concatenateQuery($sqlArray);
+            $this->buildQueryPart(static::QUERY_PART_ORDERBY, $statements),
+            $this->buildQueryPart(static::QUERY_PART_LIMIT, $statements),
+            $this->buildQueryPart(static::QUERY_PART_OFFSET, $statements),
+        ]);
 
         $sql = $this->buildUnion($statements, $sql);
 
@@ -550,6 +565,48 @@ abstract class BaseAdapter
         );
 
         return compact('sql', 'bindings');
+    }
+
+    /**
+     * Returns specific part of a query like JOIN, LIMIT, OFFSET etc.
+     *
+     * @param string $section
+     * @param array $statements
+     * @return string
+     * @throws Exception
+     */
+    protected function buildQueryPart(string $section, array $statements): string
+    {
+        switch ($section) {
+            case static::QUERY_PART_JOIN:
+                return $this->buildJoin($statements);
+            case static::QUERY_PART_LIMIT:
+                return isset($statements['limit']) ? 'LIMIT ' . $statements['limit'] : '';
+            case static::QUERY_PART_OFFSET:
+                return isset($statements['offset']) ? 'OFFSET ' . $statements['offset'] : '';
+            case static::QUERY_PART_ORDERBY:
+                $orderBys = '';
+                if (isset($statements['orderBys']) === true && \is_array($statements['orderBys']) === true) {
+                    foreach ($statements['orderBys'] as $orderBy) {
+                        $orderBys .= $this->wrapSanitizer($orderBy['field']) . ' ' . $orderBy['type'] . ', ';
+                    }
+
+                    if ($orderBys = trim($orderBys, ', ')) {
+                        $orderBys = 'ORDER BY ' . $orderBys;
+                    }
+                }
+
+                return $orderBys;
+            case static::QUERY_PART_GROUPBY:
+                $groupBys = $this->arrayStr($statements['groupBys'], ', ');
+                if ($groupBys !== '' && isset($statements['groupBys']) === true) {
+                    $groupBys = 'GROUP BY ' . $groupBys;
+                }
+
+                return $groupBys;
+        }
+
+        return '';
     }
 
     /**
@@ -604,15 +661,16 @@ abstract class BaseAdapter
         // WHERE
         [$whereCriteria, $whereBindings] = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
 
-        // LIMIT
-        $limit = isset($statements['limit']) ? 'LIMIT ' . $statements['limit'] : '';
-
         $sqlArray = [
             'UPDATE',
             $this->wrapSanitizer($table),
+            $this->buildQueryPart(static::QUERY_PART_JOIN, $statements),
             'SET ' . $updateStatement,
             $whereCriteria,
-            $limit,
+            $this->buildQueryPart(static::QUERY_PART_GROUPBY, $statements),
+            $this->buildQueryPart(static::QUERY_PART_ORDERBY, $statements),
+            $this->buildQueryPart(static::QUERY_PART_LIMIT, $statements),
+            $this->buildQueryPart(static::QUERY_PART_OFFSET, $statements),
         ];
 
         $sql = $this->concatenateQuery($sqlArray);

--- a/tests/Pecee/Pixie/QueryBuilderBehaviorTest.php
+++ b/tests/Pecee/Pixie/QueryBuilderBehaviorTest.php
@@ -326,6 +326,54 @@ class QueryBuilderTest extends TestCase
             , $builder->getQuery('update', $data)->getRawSql());
     }
 
+    /**
+     * Test delete query with all statements.
+     * Note: the statement might not be valid as some statements can't be used together.
+     *
+     * @throws Exception
+     */
+    public function testDeleteAdvancedQuery()
+    {
+
+        $this->builder
+            ->table('foo')
+            ->leftJoin('bar', 'foo.id', '=', 'bar.id')
+            ->where('bar.id', 1)
+            ->groupBy(['foo.id'])
+            ->orderBy('foo.id')
+            ->limit(1)
+            ->offset(1)
+            ->delete(['foo.status']);
+
+        $this->assertEquals(
+            'DELETE `foo`.`status` FROM `cb_foo` LEFT JOIN `cb_bar` ON `cb_foo`.`id` = `cb_bar`.`id` WHERE `cb_bar`.`id` = 1 GROUP BY `cb_foo`.`id` ORDER BY `cb_foo`.`id` ASC LIMIT 1 OFFSET 1',
+            $this->builder->getConnection()->getLastQuery()->getRawSql());
+    }
+
+    /**
+     * Test update query with all statements.
+     * Note: the statement might not be valid as some statements can't be used together.
+     *
+     * @throws Exception
+     */
+    public function testUpdateAdvancedQuery()
+    {
+
+        $this->builder
+            ->table('foo')
+            ->leftJoin('bar', 'foo.id', '=', 'bar.id')
+            ->where('bar.id', 1)
+            ->groupBy(['foo.id'])
+            ->orderBy('foo.id')
+            ->limit(1)
+            ->offset(1)
+            ->update(['foo.status' => 1]);
+
+        $this->assertEquals(
+            'UPDATE `cb_foo` LEFT JOIN `cb_bar` ON `cb_foo`.`id` = `cb_bar`.`id` SET `foo`.`status`=1 WHERE `cb_bar`.`id` = 1 GROUP BY `cb_foo`.`id` ORDER BY `cb_foo`.`id` ASC LIMIT 1 OFFSET 1',
+            $this->builder->getConnection()->getLastQuery()->getRawSql());
+    }
+
     public function testFromSubQuery()
     {
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,6 @@ use Mockery as m;
 use Pecee\Pixie\ConnectionAdapters\Mysql;
 use Pecee\Pixie\Event\EventHandler;
 use Pecee\Pixie\QueryBuilder\QueryBuilderHandler;
-use Pecee\Pixie\QueryBuilder\QueryObject;
 
 /**
  * Class TestCase
@@ -103,7 +102,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $this->mockConnection->shouldReceive('getAdapter')->andReturn(new Mysql());
         $this->mockConnection->shouldReceive('getAdapterConfig')->andReturn(['prefix' => 'cb_']);
         $this->mockConnection->shouldReceive('getEventHandler')->andReturn($eventHandler);
-        $this->mockConnection->shouldReceive('setLastQuery');
+        $this->mockConnection->shouldReceive('setLastQuery')->passthru();
+        $this->mockConnection->shouldReceive('getLastQuery')->passthru();
         $this->mockConnection->shouldReceive('connect')->andReturn($this->mockConnection);
         $this->builder = new QueryBuilderHandler($this->mockConnection);
     }


### PR DESCRIPTION
- Added support for more advanced query-statements when using update and delete (issue: #93)
- Added optional columns argument to delete method in `QueryBuilderHandler`.
- Join now supports empty key and value, which will remove the `ON` statement from the query.
- Added unit-tests for new features.