### PR TITLE
Version 4.10.0

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,3 @@
+service_name: travis-ci
+coverage_clover: _clover/clover.xml
+json_path: _clover/coveralls-upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,22 @@ before_install:
   - mysql test < ./tests/test.sql
 
 before_script:
-  - curl -sS http://getcomposer.org/installer | php
-  - php composer.phar install --prefer-source --no-interaction
+  - mkdir -p _clover
+  - ls -al
 
 script:
-  - ./vendor/bin/phpunit --verbose
+  - ./vendor/bin/phpunit --coverage-clover _clover/clover.xml
+
+install:
+  # Install composer packages
+  - travis_retry composer install --no-interaction --no-suggest
+  # Install coveralls.phar
+  - wget -c -nc --retry-connrefused --tries=0 https://github.com/php-coveralls/php-coveralls/releases/download/v2.0.0/php-coveralls.phar -O coveralls.phar
+  - chmod +x coveralls.phar
+  - php coveralls.phar --version
+
+after_success:
+  # Submit coverage report to Coveralls servers, see .coveralls.yml
+  - travis_retry php coveralls.phar -v
+  # Submit coverage report to codecov.io
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,18 @@ sudo: false
 language: php
 
 php:
-  - 7.1
+  - 7.2
+
+services:
+  - mysql
+
+before_install:
+  - mysql -e 'CREATE DATABASE IF NOT EXISTS test;'
+  - mysql test < ./tests/test.sql
 
 before_script:
   - curl -sS http://getcomposer.org/installer | php
   - php composer.phar install --prefer-source --no-interaction
 
 script:
-  - ./vendor/bin/phpunit
+  - ./vendor/bin/phpunit --verbose

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This library is stable, maintained and are used by sites around the world (check
 
 **Requirements:**
 - PHP version 7.1 or higher is required for pecee-pixie version 4.x and above (versions prior to 4.x are available [here](https://github.com/skipperbent/pixie)).
-- PDO extension enabled.
+- PDO extension.
+- PDO sql-lite extension.
 
 **Features:**
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The syntax is similar to Laravel's query builder "Eloquent", but with less overh
 This library is stable, maintained and are used by sites around the world (check the [credits](#credits)).
 
 **Requirements:**
-- PHP version 7.1 or higher is required for pecee-pixie version 4.x and above. Versions prior to 4.x are available [here](https://github.com/skipperbent/pixie).
+- PHP version 7.1 or higher is required for pecee-pixie version 4.x and above (versions prior to 4.x are available [here](https://github.com/skipperbent/pixie)).
+- PDO extension enabled.
 
 **Features:**
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     }
   ],
   "require": {
-    "php": ">=7.1"
+    "php": ">=7.1",
+    "ext-pdo": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
   ],
   "require": {
     "php": ">=7.1",
-    "ext-pdo": "*"
+    "ext-pdo": "*",
+    "ext-sqlite": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c0bcf31206c23996e228bdf8ce472e1",
+    "content-hash": "545d9a63fc67aea0e79159297d1c89bd",
     "packages": [],
     "packages-dev": [
         {
@@ -111,16 +111,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "1bac8c362b12f522fdd1f1fa3556284c91affa38"
+                "reference": "99e29d3596b16dabe4982548527d5ddf90232e99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/1bac8c362b12f522fdd1f1fa3556284c91affa38",
-                "reference": "1bac8c362b12f522fdd1f1fa3556284c91affa38",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/99e29d3596b16dabe4982548527d5ddf90232e99",
+                "reference": "99e29d3596b16dabe4982548527d5ddf90232e99",
                 "shasum": ""
             },
             "require": {
@@ -129,7 +129,8 @@
                 "php": ">=5.6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5.7|~6.1"
+                "phpdocumentor/phpdocumentor": "^2.9",
+                "phpunit/phpunit": "~5.7.10|~6.5"
             },
             "type": "library",
             "extra": {
@@ -158,8 +159,8 @@
                     "homepage": "http://davedevelopment.co.uk"
                 }
             ],
-            "description": "Mockery is a simple yet flexible PHP mock object framework for use in unit testing with PHPUnit, PHPSpec or any other testing framework. Its core goal is to offer a test double framework with a succinct API capable of clearly defining all possible object operations and interactions using a human readable Domain Specific Language (DSL). Designed as a drop in alternative to PHPUnit's phpunit-mock-objects library, Mockery is easy to integrate with PHPUnit and can operate alongside phpunit-mock-objects without the World ending.",
-            "homepage": "http://github.com/mockery/mockery",
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
             "keywords": [
                 "BDD",
                 "TDD",
@@ -172,29 +173,32 @@
                 "test double",
                 "testing"
             ],
-            "time": "2017-10-06T16:20:43+00:00"
+            "time": "2018-05-08T08:54:48+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
@@ -217,7 +221,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "time": "2018-06-11T23:09:50+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -475,33 +479,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.5",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
-                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -534,20 +538,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-02-19T10:16:54+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.3.0",
+            "version": "5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1"
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/661f34d0bd3f1a7225ef491a70a020ad23a057a1",
-                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
                 "shasum": ""
             },
             "require": {
@@ -597,7 +601,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-12-06T09:29:45+00:00"
+            "time": "2018-04-06T15:36:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -787,16 +791,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.7",
+            "version": "6.5.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6bd77b57707c236833d2b57b968e403df060c9d9"
+                "reference": "24da433d7384824d65ea93fbb462e2f31bbb494e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6bd77b57707c236833d2b57b968e403df060c9d9",
-                "reference": "6bd77b57707c236833d2b57b968e403df060c9d9",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/24da433d7384824d65ea93fbb462e2f31bbb494e",
+                "reference": "24da433d7384824d65ea93fbb462e2f31bbb494e",
                 "shasum": ""
             },
             "require": {
@@ -814,7 +818,7 @@
                 "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.5",
+                "phpunit/phpunit-mock-objects": "^5.0.9",
                 "sebastian/comparator": "^2.1",
                 "sebastian/diff": "^2.0",
                 "sebastian/environment": "^3.1",
@@ -867,20 +871,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-26T07:01:09+00:00"
+            "time": "2018-08-22T06:32:48+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.6",
+            "version": "5.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf"
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
                 "shasum": ""
             },
             "require": {
@@ -893,7 +897,7 @@
                 "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.5"
+                "phpunit/phpunit": "^6.5.11"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -926,7 +930,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-01-06T05:45:45+00:00"
+            "time": "2018-08-09T05:50:03+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1584,7 +1588,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1"
+        "php": ">=7.1",
+        "ext-pdo": "*"
     },
     "platform-dev": []
 }

--- a/src/Pecee/Pixie/Connection.php
+++ b/src/Pecee/Pixie/Connection.php
@@ -25,12 +25,12 @@ class Connection
      *
      * @var IConnectionAdapter
      */
-    protected static $adapter;
+    protected $adapter;
 
     /**
      * @var array
      */
-    protected static $adapterConfig;
+    protected $adapterConfig;
 
     /**
      * @var \PDO
@@ -102,7 +102,7 @@ class Connection
      */
     public function getAdapter(): IConnectionAdapter
     {
-        return static::$adapter;
+        return $this->adapter;
     }
 
     /**
@@ -110,7 +110,7 @@ class Connection
      */
     public function getAdapterConfig(): array
     {
-        return static::$adapterConfig;
+        return $this->adapterConfig;
     }
 
     /**
@@ -147,7 +147,7 @@ class Connection
      */
     public function setAdapter(IConnectionAdapter $adapter): self
     {
-        static::$adapter = $adapter;
+        $this->adapter = $adapter;
 
         return $this;
     }
@@ -159,7 +159,7 @@ class Connection
      */
     public function setAdapterConfig(array $adapterConfig): self
     {
-        static::$adapterConfig = $adapterConfig;
+        $this->adapterConfig = $adapterConfig;
 
         return $this;
     }

--- a/src/Pecee/Pixie/Connection.php
+++ b/src/Pecee/Pixie/Connection.php
@@ -74,10 +74,6 @@ class Connection
      */
     public static function getStoredConnection(): self
     {
-        if (static::$storedConnection === null && static::$adapter !== null && static::$adapterConfig !== null) {
-            static::$storedConnection = new static(static::$adapter, static::$adapterConfig);
-        }
-
         return static::$storedConnection;
     }
 

--- a/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -21,6 +21,31 @@ abstract class BaseAdapter
     public const SANITIZER = '`';
 
     /**
+     * @var string
+     */
+    protected const QUERY_PART_JOIN = 'JOIN';
+
+    /**
+     * @var string
+     */
+    protected const QUERY_PART_ORDERBY = 'ORDERBY';
+
+    /**
+     * @var string
+     */
+    protected const QUERY_PART_LIMIT = 'LIMIT';
+
+    /**
+     * @var string
+     */
+    protected const QUERY_PART_OFFSET = 'OFFSET';
+
+    /**
+     * @var string
+     */
+    protected const QUERY_PART_GROUPBY = 'GROUPBY';
+
+    /**
      * @var \Pecee\Pixie\Connection
      */
     protected $connection;
@@ -246,8 +271,7 @@ abstract class BaseAdapter
                 strtoupper($joinArr['type']),
                 'JOIN',
                 $table,
-
-                $joinBuilder->getQuery('criteriaOnly', false)->getSql(),
+                $joinBuilder instanceof QueryBuilderHandler ? $joinBuilder->getQuery('criteriaOnly', false)->getSql() : '',
             ];
 
             $sql = $this->concatenateQuery($sqlArr);
@@ -298,19 +322,40 @@ abstract class BaseAdapter
      * Build delete query
      *
      * @param array $statements
+     * @param array|null $columns
      *
      * @return array
      * @throws Exception
      */
-    public function delete(array $statements): array
+    public function delete(array $statements, array $columns = null): array
     {
         $table = end($statements['tables']);
+
+        $columnsQuery = '';
+
+        if($columns !== null) {
+            foreach($columns as $key => $column) {
+                $columns[$key] = $this->wrapSanitizer($column);
+            }
+
+            $columnsQuery = implode(', ', $columns);
+        }
 
         // WHERE
         [$whereCriteria, $whereBindings] = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
 
-        $sqlArray = ['DELETE FROM', $this->wrapSanitizer($table), $whereCriteria];
-        $sql = $this->concatenateQuery($sqlArray);
+        $sql = $this->concatenateQuery([
+            'DELETE ',
+            $columnsQuery,
+            ' FROM',
+            $this->wrapSanitizer($table),
+            $this->buildQueryPart(static::QUERY_PART_JOIN, $statements),
+            $whereCriteria,
+            $this->buildQueryPart(static::QUERY_PART_GROUPBY, $statements),
+            $this->buildQueryPart(static::QUERY_PART_ORDERBY, $statements),
+            $this->buildQueryPart(static::QUERY_PART_LIMIT, $statements),
+            $this->buildQueryPart(static::QUERY_PART_OFFSET, $statements),
+        ]);
         $bindings = $whereBindings;
 
         return compact('sql', 'bindings');
@@ -492,55 +537,25 @@ abstract class BaseAdapter
             $fromEnabled = true;
         }
 
-        // SELECT
-        $selects = $this->arrayStr($statements['selects'], ', ');
-
         // WHERE
         [$whereCriteria, $whereBindings] = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
-
-        // GROUP BY
-        $groupBys = $this->arrayStr($statements['groupBys'], ', ');
-        if ($groupBys !== '' && isset($statements['groupBys']) === true) {
-            $groupBys = 'GROUP BY ' . $groupBys;
-        }
-
-        // ORDER BY
-        $orderBys = '';
-        if (isset($statements['orderBys']) === true && \is_array($statements['orderBys']) === true) {
-            foreach ($statements['orderBys'] as $orderBy) {
-                $orderBys .= $this->wrapSanitizer($orderBy['field']) . ' ' . $orderBy['type'] . ', ';
-            }
-
-            if ($orderBys = trim($orderBys, ', ')) {
-                $orderBys = 'ORDER BY ' . $orderBys;
-            }
-        }
-
-        // LIMIT AND OFFSET
-        $limit = isset($statements['limit']) ? 'LIMIT ' . $statements['limit'] : '';
-        $offset = isset($statements['offset']) ? 'OFFSET ' . $statements['offset'] : '';
 
         // HAVING
         [$havingCriteria, $havingBindings] = $this->buildCriteriaWithType($statements, 'havings', 'HAVING');
 
-        // JOINS
-        $joinString = $this->buildJoin($statements);
-
-        $sqlArray = [
+        $sql = $this->concatenateQuery([
             'SELECT' . ($hasDistincts === true ? ' DISTINCT' : ''),
-            $selects,
+            $this->arrayStr($statements['selects'], ', '),
             $fromEnabled ? 'FROM' : '',
             $tables,
-            $joinString,
+            $this->buildQueryPart(static::QUERY_PART_JOIN, $statements),
             $whereCriteria,
-            $groupBys,
+            $this->buildQueryPart(static::QUERY_PART_GROUPBY, $statements),
             $havingCriteria,
-            $orderBys,
-            $limit,
-            $offset,
-        ];
-
-        $sql = $this->concatenateQuery($sqlArray);
+            $this->buildQueryPart(static::QUERY_PART_ORDERBY, $statements),
+            $this->buildQueryPart(static::QUERY_PART_LIMIT, $statements),
+            $this->buildQueryPart(static::QUERY_PART_OFFSET, $statements),
+        ]);
 
         $sql = $this->buildUnion($statements, $sql);
 
@@ -550,6 +565,48 @@ abstract class BaseAdapter
         );
 
         return compact('sql', 'bindings');
+    }
+
+    /**
+     * Returns specific part of a query like JOIN, LIMIT, OFFSET etc.
+     *
+     * @param string $section
+     * @param array $statements
+     * @return string
+     * @throws Exception
+     */
+    protected function buildQueryPart(string $section, array $statements): string
+    {
+        switch ($section) {
+            case static::QUERY_PART_JOIN:
+                return $this->buildJoin($statements);
+            case static::QUERY_PART_LIMIT:
+                return isset($statements['limit']) ? 'LIMIT ' . $statements['limit'] : '';
+            case static::QUERY_PART_OFFSET:
+                return isset($statements['offset']) ? 'OFFSET ' . $statements['offset'] : '';
+            case static::QUERY_PART_ORDERBY:
+                $orderBys = '';
+                if (isset($statements['orderBys']) === true && \is_array($statements['orderBys']) === true) {
+                    foreach ($statements['orderBys'] as $orderBy) {
+                        $orderBys .= $this->wrapSanitizer($orderBy['field']) . ' ' . $orderBy['type'] . ', ';
+                    }
+
+                    if ($orderBys = trim($orderBys, ', ')) {
+                        $orderBys = 'ORDER BY ' . $orderBys;
+                    }
+                }
+
+                return $orderBys;
+            case static::QUERY_PART_GROUPBY:
+                $groupBys = $this->arrayStr($statements['groupBys'], ', ');
+                if ($groupBys !== '' && isset($statements['groupBys']) === true) {
+                    $groupBys = 'GROUP BY ' . $groupBys;
+                }
+
+                return $groupBys;
+        }
+
+        return '';
     }
 
     /**
@@ -604,15 +661,16 @@ abstract class BaseAdapter
         // WHERE
         [$whereCriteria, $whereBindings] = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
 
-        // LIMIT
-        $limit = isset($statements['limit']) ? 'LIMIT ' . $statements['limit'] : '';
-
         $sqlArray = [
             'UPDATE',
             $this->wrapSanitizer($table),
+            $this->buildQueryPart(static::QUERY_PART_JOIN, $statements),
             'SET ' . $updateStatement,
             $whereCriteria,
-            $limit,
+            $this->buildQueryPart(static::QUERY_PART_GROUPBY, $statements),
+            $this->buildQueryPart(static::QUERY_PART_ORDERBY, $statements),
+            $this->buildQueryPart(static::QUERY_PART_LIMIT, $statements),
+            $this->buildQueryPart(static::QUERY_PART_OFFSET, $statements),
         ];
 
         $sql = $this->concatenateQuery($sqlArray);

--- a/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -504,10 +504,8 @@ abstract class BaseAdapter
                 $statements['selects'] = $statements['distincts'];
             }
 
-        } else {
-            if (isset($statements['selects']) === false) {
-                $statements['selects'] = ['*'];
-            }
+        } else if (isset($statements['selects']) === false) {
+            $statements['selects'] = ['*'];
         }
 
         // From

--- a/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -145,11 +145,11 @@ class QueryBuilderHandler implements IQueryBuilderHandler
      * @param string $field
      *
      * @throws Exception
-     * @return float
+     * @return integer
      */
-    public function count(string $field = '*'): float
+    public function count(string $field = '*'): int
     {
-        return $this->aggregate('count', $field);
+        return (int) $this->aggregate('count', $field);
     }
 
     /**

--- a/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -1603,7 +1603,21 @@ class QueryBuilderHandler implements IQueryBuilderHandler
      */
     public function getColumns(): array
     {
-        return isset($this->statements['selects']) === true ? array_values($this->statements['selects'])[0] : [];
+        $tSelects = isset($this->statements['selects']) === true ? $this->statements['selects'] : [];
+        $tColumns = [];
+        foreach ($tSelects as $key => $value) {
+            if (\is_string($value)) {
+                if (\is_int($key)) {
+                    $tElements = explode('.', $value);
+                    if (!\in_array('*', $tElements, true)) {
+                        $tColumns[$tElements[1] ?? $tElements[0]] = $value;
+                    }
+                } elseif (\is_string($key)) {
+                    $tColumns[$value] = $key;
+                }
+            }
+        }
+        return $tColumns;
     }
 
     /**

--- a/tests/Pecee/Pixie/ConnectionTest.php
+++ b/tests/Pecee/Pixie/ConnectionTest.php
@@ -44,4 +44,45 @@ class ConnectionTest extends TestCase
         $this->assertInstanceOf(IConnectionAdapter::class, $this->connection->getAdapter());
         $this->assertEquals(['prefix' => 'cb_'], $this->connection->getAdapterConfig());
     }
+
+    /**
+     * Test multiple connections
+     * @throws Exception
+     */
+    public function testMultiConnection()
+    {
+        $mysqlMock = m::mock(Mysql::class);
+        $mysqlMock->shouldReceive('connect')->andReturn($this->mockPdo);
+        $mysqlMock->shouldReceive('getQueryAdapterClass')->andReturn(\Pecee\Pixie\QueryBuilder\Adapters\Mysql::class);
+
+        $connectionOneHost = 'google.com';
+        $connectionTwoHost = 'yahoo.com';
+
+        $connectionOne = new Connection($mysqlMock, [
+            'database' => 'db',
+            'username' => 'username',
+            'password' => 'password',
+            'host'     => $connectionOneHost,
+        ]);
+
+        $connectionTwo = new Connection($mysqlMock, [
+            'database' => 'db',
+            'username' => 'username',
+            'password' => 'password',
+            'host'     => $connectionTwoHost,
+        ]);
+
+        $adapterConfigOne = $connectionOne
+            ->getQueryBuilder()
+            ->getConnection()
+            ->getAdapterConfig();
+
+        $adapterConfigTwo = $connectionTwo
+            ->getQueryBuilder()
+            ->getConnection()
+            ->getAdapterConfig();
+
+        $this->assertEquals($adapterConfigOne['host'], $connectionOneHost);
+        $this->assertEquals($adapterConfigTwo['host'], $connectionTwoHost);
+    }
 }

--- a/tests/Pecee/Pixie/CustomExceptionsTest.php
+++ b/tests/Pecee/Pixie/CustomExceptionsTest.php
@@ -26,11 +26,11 @@ class CustomExceptionsTest extends TestCase
         return $con->getQueryBuilder();
     }
 
-    protected function validateException(\Exception $exception, $class, $code = null)
+    protected function validateException(\Exception $exception, $class, ...$codes)
     {
 
-        if ($code !== null) {
-            $this->assertEquals($code, $exception->getCode());
+        if ($codes !== null) {
+            $this->assertContains($exception->getCode(), $codes, sprintf('Failed asserting exception- expected "%s" got "%s"', implode(' or ', $codes), $exception->getCode()));
         }
 
         $this->assertEquals($class, \get_class($exception));
@@ -78,13 +78,15 @@ class CustomExceptionsTest extends TestCase
                 'host'      => '127.0.0.1',
                 'database'  => 'test',
                 'username'  => 'nopermuser',
-                'password'  => '',
+                'password'  => 'password',
                 'charset'   => 'utf8mb4', // Optional
                 'collation' => 'utf8mb4_unicode_ci', // Optional
                 'prefix'    => '', // Table prefix, optional
             ]))->connect();
         } catch (\Exception $e) {
-            $this->validateException($e, ConnectionException::class, 1044);
+
+            // Note: seems like some MySQL instances returns 1044 other 1045.
+            $this->validateException($e, ConnectionException::class, 1044, 1045);
         }
 
     }

--- a/tests/Pecee/Pixie/CustomExceptionsTest.php
+++ b/tests/Pecee/Pixie/CustomExceptionsTest.php
@@ -55,7 +55,7 @@ class CustomExceptionsTest extends TestCase
             $this->validateException($e, ConnectionException::class, 2002);
         }
 
-        // test error code 1045
+        // test error code 1045 - access denied do server
         try {
             (new \Pecee\Pixie\Connection('mysql', [
                 'driver'    => 'mysql',
@@ -71,7 +71,7 @@ class CustomExceptionsTest extends TestCase
             $this->validateException($e, ConnectionException::class, 1045);
         }
 
-        // test error code 1044
+        // test error code 1045 - access denied do server
         try {
             (new \Pecee\Pixie\Connection('mysql', [
                 'driver'    => 'mysql',
@@ -79,6 +79,22 @@ class CustomExceptionsTest extends TestCase
                 'database'  => 'root',
                 'username'  => 'nonexisting',
                 'password'  => '',
+                'charset'   => 'utf8mb4', // Optional
+                'collation' => 'utf8mb4_unicode_ci', // Optional
+                'prefix'    => '', // Table prefix, optional
+            ]))->connect();
+        } catch (\Exception $e) {
+            $this->validateException($e, ConnectionException::class, 1045);
+        }
+
+        // test error code 1044 - access to specific DB denied
+        try {
+            (new \Pecee\Pixie\Connection('mysql', [
+                'driver'    => 'mysql',
+                'host'      => '127.0.0.1',
+                'database'  => 'test',
+                'username'  => 'nopermuser',
+                'password'  => 'password',
                 'charset'   => 'utf8mb4', // Optional
                 'collation' => 'utf8mb4_unicode_ci', // Optional
                 'prefix'    => '', // Table prefix, optional

--- a/tests/Pecee/Pixie/CustomExceptionsTest.php
+++ b/tests/Pecee/Pixie/CustomExceptionsTest.php
@@ -55,30 +55,14 @@ class CustomExceptionsTest extends TestCase
             $this->validateException($e, ConnectionException::class, 2002);
         }
 
-        // test error code 1045 - access denied do server
+        // test error code 1045 - access for user/pass denied to server (wrong username/password)
         try {
             (new \Pecee\Pixie\Connection('mysql', [
                 'driver'    => 'mysql',
                 'host'      => '127.0.0.1',
-                'database'  => 'test',
-                'username'  => 'root',
-                'password'  => 'asdasdasd',
-                'charset'   => 'utf8mb4', // Optional
-                'collation' => 'utf8mb4_unicode_ci', // Optional
-                'prefix'    => '', // Table prefix, optional
-            ]))->connect();
-        } catch (\Exception $e) {
-            $this->validateException($e, ConnectionException::class, 1045);
-        }
-
-        // test error code 1045 - access denied do server
-        try {
-            (new \Pecee\Pixie\Connection('mysql', [
-                'driver'    => 'mysql',
-                'host'      => '127.0.0.1',
-                'database'  => 'root',
+                'database'  => 'db',
                 'username'  => 'nonexisting',
-                'password'  => '',
+                'password'  => 'password',
                 'charset'   => 'utf8mb4', // Optional
                 'collation' => 'utf8mb4_unicode_ci', // Optional
                 'prefix'    => '', // Table prefix, optional
@@ -87,14 +71,14 @@ class CustomExceptionsTest extends TestCase
             $this->validateException($e, ConnectionException::class, 1045);
         }
 
-        // test error code 1044 - access to specific DB denied
+        // test error code 1044 - access to specific DB denied for user
         try {
             (new \Pecee\Pixie\Connection('mysql', [
                 'driver'    => 'mysql',
                 'host'      => '127.0.0.1',
                 'database'  => 'test',
                 'username'  => 'nopermuser',
-                'password'  => 'password',
+                'password'  => '',
                 'charset'   => 'utf8mb4', // Optional
                 'collation' => 'utf8mb4_unicode_ci', // Optional
                 'prefix'    => '', // Table prefix, optional

--- a/tests/Pecee/Pixie/QueryBuilderAggregateTest.php
+++ b/tests/Pecee/Pixie/QueryBuilderAggregateTest.php
@@ -31,6 +31,7 @@ class QueryBuilderAggregateTest extends TestCase
         $count = $qb->from('animal')->groupBy('number_of_legs')->count();
 
         $this->assertEquals(3, $count);
+        $this->assertEquals('integer', \gettype($count));
     }
 
     public function testQuerySum()

--- a/tests/Pecee/Pixie/QueryBuilderBehaviorTest.php
+++ b/tests/Pecee/Pixie/QueryBuilderBehaviorTest.php
@@ -326,6 +326,54 @@ class QueryBuilderTest extends TestCase
             , $builder->getQuery('update', $data)->getRawSql());
     }
 
+    /**
+     * Test delete query with all statements.
+     * Note: the statement might not be valid as some statements can't be used together.
+     *
+     * @throws Exception
+     */
+    public function testDeleteAdvancedQuery()
+    {
+
+        $this->builder
+            ->table('foo')
+            ->leftJoin('bar', 'foo.id', '=', 'bar.id')
+            ->where('bar.id', 1)
+            ->groupBy(['foo.id'])
+            ->orderBy('foo.id')
+            ->limit(1)
+            ->offset(1)
+            ->delete(['foo.status']);
+
+        $this->assertEquals(
+            'DELETE `foo`.`status` FROM `cb_foo` LEFT JOIN `cb_bar` ON `cb_foo`.`id` = `cb_bar`.`id` WHERE `cb_bar`.`id` = 1 GROUP BY `cb_foo`.`id` ORDER BY `cb_foo`.`id` ASC LIMIT 1 OFFSET 1',
+            $this->builder->getConnection()->getLastQuery()->getRawSql());
+    }
+
+    /**
+     * Test update query with all statements.
+     * Note: the statement might not be valid as some statements can't be used together.
+     *
+     * @throws Exception
+     */
+    public function testUpdateAdvancedQuery()
+    {
+
+        $this->builder
+            ->table('foo')
+            ->leftJoin('bar', 'foo.id', '=', 'bar.id')
+            ->where('bar.id', 1)
+            ->groupBy(['foo.id'])
+            ->orderBy('foo.id')
+            ->limit(1)
+            ->offset(1)
+            ->update(['foo.status' => 1]);
+
+        $this->assertEquals(
+            'UPDATE `cb_foo` LEFT JOIN `cb_bar` ON `cb_foo`.`id` = `cb_bar`.`id` SET `foo`.`status`=1 WHERE `cb_bar`.`id` = 1 GROUP BY `cb_foo`.`id` ORDER BY `cb_foo`.`id` ASC LIMIT 1 OFFSET 1',
+            $this->builder->getConnection()->getLastQuery()->getRawSql());
+    }
+
     public function testFromSubQuery()
     {
 

--- a/tests/Pecee/Pixie/QueryBuilderTest.php
+++ b/tests/Pecee/Pixie/QueryBuilderTest.php
@@ -161,13 +161,4 @@ class QueryBuilder extends TestCase
 
     }
 
-    public function testCountQuery() {
-        $subquery = $this->builder
-            ->newQuery()
-            ->table('foo_table');
-        $oCall = $this->builder->newQuery()->table($this->builder->subQuery($subquery,'q1'))->count();
-
-        die(var_dump($subquery->getLastQuery()->getRawSql()));
-    }
-
 }

--- a/tests/Pecee/Pixie/QueryBuilderTest.php
+++ b/tests/Pecee/Pixie/QueryBuilderTest.php
@@ -161,6 +161,29 @@ class QueryBuilder extends TestCase
 
     }
 
+    /**
+     * @throws \Pecee\Pixie\Exception
+     */
+    public function testGetColumns(){
+        $query = $this->builder
+            ->newQuery()
+            ->table(['foo_table','foo'])
+            ->leftJoin(['bar_table','bar'],'foo._barId','=','bar.id')
+            ->leftJoin(['baz_table','baz'],'bar._bazId','=','baz.id')
+            ->select([
+                'foo.*',
+                'bar.id'=>'barId',
+                'name',
+                $this->builder->raw('baz.name as bazName')
+            ])
+        ;
+        $this->assertEquals([
+            'barId' =>  'cb_bar.id',
+            'name'  =>  'name'
+        ],$query->getColumns());
+    }
+
+
     public function testCountQuery() {
         $subquery = $this->builder
             ->newQuery()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,6 @@ use Mockery as m;
 use Pecee\Pixie\ConnectionAdapters\Mysql;
 use Pecee\Pixie\Event\EventHandler;
 use Pecee\Pixie\QueryBuilder\QueryBuilderHandler;
-use Pecee\Pixie\QueryBuilder\QueryObject;
 
 /**
  * Class TestCase
@@ -103,7 +102,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
         $this->mockConnection->shouldReceive('getAdapter')->andReturn(new Mysql());
         $this->mockConnection->shouldReceive('getAdapterConfig')->andReturn(['prefix' => 'cb_']);
         $this->mockConnection->shouldReceive('getEventHandler')->andReturn($eventHandler);
-        $this->mockConnection->shouldReceive('setLastQuery');
+        $this->mockConnection->shouldReceive('setLastQuery')->passthru();
+        $this->mockConnection->shouldReceive('getLastQuery')->passthru();
         $this->mockConnection->shouldReceive('connect')->andReturn($this->mockConnection);
         $this->builder = new QueryBuilderHandler($this->mockConnection);
     }

--- a/tests/test.sql
+++ b/tests/test.sql
@@ -18,3 +18,5 @@ CREATE TABLE `animal` (
 )
 COLLATE='latin1_swedish_ci'
 ;
+
+CREATE USER 'nopermuser'@'%' identified by 'password'; FLUSH PRIVILEGES;

--- a/tests/test.sql
+++ b/tests/test.sql
@@ -18,3 +18,14 @@ CREATE TABLE `animal` (
 )
 COLLATE='latin1_swedish_ci'
 ;
+
+
+INSERT INTO `people` (`id`,`name`,`nickname`,`age`,`awesome`) VALUES
+(1,'Simon','ponylover94',12,1),
+(2,'Peter',NULL,40,0),
+(3,'Bobby','peter',20,1);
+
+INSERT INTO `animal` (`id`,`name`,`number_of_legs`) VALUES
+(1,'mouse',28),
+(2,'horse',4),
+(3,'cat',8);


### PR DESCRIPTION
- Fixed wrong return-type when using `COUNT` (issue #91).
- Fixed only strict names taken into account with no wildcard * and/or `Raw` instances (issue: #92).
- Added Travis-ci with MySQL support (issue: #97)
- Added PDO extension to composer file and added PDO extension as requirement in README.
- Added SQLite extension to composer file and added PDO extension as requirement in README.
- Fixed connections overlapping when using multiple connections (issue #98)
- Added support for more advanced query-statements when using update and delete (issue: #93)
- Added optional `$columns` argument to `delete` method in `QueryBuilderHandler` to specify which columns to delete.
- Join now supports empty key and value, which will remove the `ON` statement from the query.
- Added unit-tests for new features.
- Added unit tests for multiple connections.
- Minor optimisations.