### PR TITLE
Fix alias case sensitivity for table aliases, improve bindings, support where() closure didn't add any criteria (empty closure) 

### DIFF
--- a/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -186,11 +186,23 @@ abstract class BaseAdapter
                 // Get the criteria only query from the nestedCriteria object
                 $queryObject = $nestedCriteria->getQuery('criteriaOnly', true);
 
+                // Skip if the closure didn't add any criteria (empty closure)
+                $sql = $queryObject->getSql();
+                if (trim($sql) === '')
+                {
+                    // Remove the joiner (AND/OR) that was already pushed before the closure check
+                    if ($joiner !== '')
+                    {
+                        array_pop($criteria);
+                    }
+                    continue;
+                }
+
                 // Merge the bindings we get from nestedCriteria object
                 $bindings[] = $queryObject->getBindings();
 
                 // Append the sql we get from the nestedCriteria object
-                $criteria[] = "({$queryObject->getSql()})";
+                $criteria[] = "({$sql})";
 
                 continue;
             }
@@ -375,7 +387,8 @@ abstract class BaseAdapter
      */
     public function criteriaOnly(array $statements, $bindValues = true): array
     {
-        $sql = $bindings = [];
+        $sql = '';
+        $bindings = [];
         if (isset($statements['criteria']) === false) {
             return compact('sql', 'bindings');
         }

--- a/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -358,7 +358,7 @@ abstract class BaseAdapter
     {
         $this->aliasPrefix = $statements['aliases'][$table] ?? null;
         if ($this->aliasPrefix !== null) {
-            return sprintf('%s AS %s', $this->wrapSanitizer($table), $this->wrapSanitizer(strtolower($this->aliasPrefix)));
+            return sprintf('%s AS %s', $this->wrapSanitizer($table), $this->wrapSanitizer($this->aliasPrefix));
         }
 
         return sprintf('%s', $this->wrapSanitizer($table));

--- a/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -493,7 +493,7 @@ abstract class BaseAdapter
 
             if ($value instanceof Raw) {
                 $statements[] = $statement . $value;
-                $bindings += $value->getBindings();
+                $bindings = array_merge($bindings, (array)$value->getBindings()); // fixed
             } else {
                 $statements[] = $statement . '?';
                 $bindings[] = $value;

--- a/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/BaseAdapter.php
@@ -443,7 +443,7 @@ abstract class BaseAdapter
             $keys[] = $key;
             if ($value instanceof Raw) {
                 $values[] = (string)$value;
-                $bindings[] = $value->getBindings();
+                $bindings = array_merge($bindings, (array)$value->getBindings());  // ✅ FIXED
             } else {
                 $values[] = '?';
                 $bindings[] = $value;

--- a/src/Pecee/Pixie/QueryBuilder/Adapters/Sqlserver.php
+++ b/src/Pecee/Pixie/QueryBuilder/Adapters/Sqlserver.php
@@ -75,7 +75,7 @@ class Sqlserver extends BaseAdapter
                     $prefix = $statements['aliases'][$table] ?? null;
 
                     if ($prefix !== null) {
-                        $t = sprintf('%s AS %s', $table, strtolower($prefix));
+                        $t = sprintf('%s AS %s', $table, $prefix);
                     } else {
                         $t = sprintf('%s', $table);
                     }

--- a/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
+++ b/src/Pecee/Pixie/QueryBuilder/QueryBuilderHandler.php
@@ -698,7 +698,7 @@ class QueryBuilderHandler implements IQueryBuilderHandler
             $table = $this->tablePrefix . $table;
         }
 
-        $this->statements['aliases'][$table] = \strtolower($alias);
+        $this->statements['aliases'][$table] = $alias;
 
         return $this;
     }


### PR DESCRIPTION
This pull request focuses on improving alias handling and fixing binding issues in the query builder. The most significant changes address how table aliases are managed (removing forced lowercasing), correct how bindings are merged for raw values, and enhance criteria building logic for nested queries.

**Alias handling improvements:**

* Stopped forcing lowercase on table aliases in `alias` method of `QueryBuilderHandler` and related adapter methods, ensuring aliases retain their original casing throughout query construction. [[1]](diffhunk://#diff-bec851f695411cb42d0d9da24b630881619538fb274e8534b7f3d2485211c3bdL701-R701) [[2]](diffhunk://#diff-6efed79547a1b4ed888ac8960e0bf36d1c326efaad21d34c0ac3bc36a6acf69bL361-R373) [[3]](diffhunk://#diff-e6d3cb86e42426f6113e5674fdd60f30f74c416e651a4761770db700af389048L78-R78)

**Binding and criteria logic fixes:**

* Fixed how bindings are merged for `Raw` values in both `doInsert` and `getUpdateStatement` methods in `BaseAdapter`, ensuring all bindings are properly included using `array_merge`. [[1]](diffhunk://#diff-6efed79547a1b4ed888ac8960e0bf36d1c326efaad21d34c0ac3bc36a6acf69bL446-R459) [[2]](diffhunk://#diff-6efed79547a1b4ed888ac8960e0bf36d1c326efaad21d34c0ac3bc36a6acf69bL496-R509)
* whare(function(){ }) Improved criteria building skipping empty closures and removing unnecessary joiners, preventing invalid SQL generation.
```
->where(function ($q){
   if (isAdmin(true)) {
      $q->where('so.isAdmin', true);
   } else {
   // empty closure
   }
})
```

**Bindings Handling Fixes:**

* Bindings from raw SQL values are now merged correctly using `array_merge` in both insert and update operations, ensuring all bindings are included and preserving the correct order. [[1]](diffhunk://#diff-6efed79547a1b4ed888ac8960e0bf36d1c326efaad21d34c0ac3bc36a6acf69bL446-R459) [[2]](diffhunk://#diff-6efed79547a1b4ed888ac8960e0bf36d1c326efaad21d34c0ac3bc36a6acf69bL496-R509)